### PR TITLE
refactor: add engine state foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,13 +39,13 @@ uv run python -m pytest tests/path/to/test_file.py::test_name
 
 Use a `src/` layout as the project grows:
 
-- `src/camel_up/core`: game state, rules, scoring, legal actions
+- `src/camel_up/engine`: game state, rules, scoring, legal actions
 - `src/camel_up/cli`: command-line interface
 - `src/camel_up/agents`: random, heuristic, search, and learning agents
 - `src/camel_up/envs`: Gymnasium-style RL wrappers
 
-Core logic must not depend on CLI, agents, or RL environment code. CLI, agent,
-and RL code must use stable core APIs rather than duplicating rules.
+Engine logic must not depend on CLI, agents, or RL environment code. CLI,
+agent, and RL code must use stable engine APIs rather than duplicating rules.
 
 ## Code Standards
 
@@ -61,6 +61,8 @@ and RL code must use stable core APIs rather than duplicating rules.
 ## Game And RL Rules
 
 - Preserve camel stack ordering semantics.
+- Treat initial camel placement as an atomic transition: valid board snapshots
+  contain either no placed camels before setup or all camels after setup.
 - Treat crazy camels, grey die behavior, spectator tiles, leg resets, game end,
   legal actions, observation encoding, and rewards as high-risk areas.
 - Add or update tests when changing rules.

--- a/README.md
+++ b/README.md
@@ -43,14 +43,17 @@ Run pre-commit checks manually:
 uv run pre-commit run --all-files
 ```
 
-## Project Direction
+## Project Structure
 
-The project will move toward a `src/` layout:
+The project uses a `src/` layout as it moves from the prototype CLI to the
+deterministic engine:
 
-- `src/camel_up/core`: game state, rules, scoring, legal actions
+- `src/camel_up/engine`: game state, rules, scoring, and legal actions
 - `src/camel_up/cli`: command-line interface
 - `src/camel_up/agents`: random, heuristic, search, and learning agents
 - `src/camel_up/envs`: Gymnasium-style RL wrappers
 
-Core rules should be deterministic, testable, and independent from CLI, agent,
-or training code.
+Engine rules are deterministic, testable, and independent from CLI, agent, or
+training code. Initial camel placement is modeled as one atomic transition from
+an all-unplaced pre-setup state to a complete board; setup rolls do not create
+player decision states for agents or search.

--- a/components.py
+++ b/components.py
@@ -1,8 +1,5 @@
-"""Temporary compatibility imports for the prototype CLI.
+"""Temporary compatibility imports for the prototype CLI."""
 
-New code should import these types from :mod:`camel_up.engine`.
-"""
+from camel_up.cli.legacy_components import Board, Camel
 
-from camel_up.engine import Board, Camel, GameState
-
-__all__ = ["Board", "Camel", "GameState"]
+__all__ = ["Board", "Camel"]

--- a/components.py
+++ b/components.py
@@ -1,84 +1,8 @@
-import random
+"""Temporary compatibility imports for the prototype CLI.
 
-class Board:
+New code should import these types from :mod:`camel_up.engine`.
+"""
 
-    '''
-    board object
+from camel_up.engine import Board, Camel, GameState
 
-    input:
-      land_len: int
-        number of the blocks
-    '''
-    def __init__(self, land_len):
-
-        self.blocks = [[] for _ in range(land_len)]
-        self.spectator_tiles = {}
-        self.dices = ['red', 'blue', 'green', 'yellow', 'purple', 'grey']
-
-    def toss_dice(self):
-
-        current_number_of_dices = len(self.dices)
-        select_camel_id = random.randint(0, current_number_of_dices - 1)
-        step = random.randint(1, 3)
-
-        color = self.dices.pop(select_camel_id)
-
-        return color, step
-
-    def place_camel(self, block_id, camels, forward=True):
-
-        # camels must be list of camle object(s)
-        if forward:
-            self.blocks[block_id] += camels
-        else:
-            self.blocks[block_id] = camels + self.blocks[block_id]
-
-        self.update_camels(block_id)
-
-    def update_camels(self, block_id):
-
-        stack_id_ini = 0
-        for camel in self.blocks[block_id]:
-            camel.block_id = block_id
-            camel.stack_id = stack_id_ini
-            stack_id_ini += 1
-
-    def select_camel(self, camel):
-
-        block_id = camel.block_id
-        stack_id = camel.stack_id
-
-        camel_to_move = self.blocks[block_id][stack_id:]
-        self.blocks[block_id] = self.blocks[block_id][:stack_id]
-        return camel_to_move
-
-    def place_spectator_tile(self, block_id, side):
-
-        if len(self.block[block_id] != 0):
-            print('Place your spectator tile into an empty space.')
-        elif ((block_id - 1) in self.spectator_tiles or 
-              (block_id + 1) in self.spectator_tiles):
-            print('You are not allowed to place the spectator tile'
-                  'onto a space that is adjacent to a space containing'
-                  'a spectator tile.')
-        else:
-            self.spectator_tiles[block_id] = side
-
-    def one_leg_reset(self):
-
-        self.spectator_tiles = {}
-        self.dices = ['red', 'blue', 'green', 'yellow', 'purple', 'grey']
-
-
-class Camel:
-
-    '''
-    Camel object
-
-    '''
-    
-    def __init__(self, color, block_id=None, stack_id=None):
-
-        self.color = color
-        self.block_id = block_id
-        self.stack_id = stack_id
+__all__ = ["Board", "Camel", "GameState"]

--- a/docs/software-foundation-plan.md
+++ b/docs/software-foundation-plan.md
@@ -106,8 +106,9 @@ tests/
 
 Module responsibilities:
 
-- `engine.state`: Domain dataclasses and state containers such as `Camel`,
-  `Board`, `GameState`, `DieRoll`, `SpectatorTile`, and player state.
+- `engine.state`: Immutable domain dataclasses and state containers such as
+  `CamelPosition`, `BoardState`, `GameState`, `DieRoll`, `SpectatorTile`, and
+  player state.
 - `engine.dice`: Dice inventory, dice selection, grey die handling, and seeded
   roll behavior.
 - `engine.movement`: Camel stack selection, placement, forward movement,
@@ -138,7 +139,8 @@ Tasks:
 
 - [ ] Create `src/camel_up/engine` with semantic modules rather than one large
       `board.py` or `rules.py`.
-- [ ] Move `Camel` and `Board` out of root-level `components.py`.
+- [ ] Replace the mutable `Camel` and `Board` state model with canonical engine
+      coordinates, retaining prototype adapters only while the CLI needs them.
 - [ ] Introduce `GameState` before adding more rule behavior.
 - [ ] Put movement rules in `engine.movement`, dice rules in `engine.dice`,
       tile rules in `engine.tiles`, betting rules in `engine.betting`, and
@@ -179,21 +181,26 @@ Tasks:
 - [ ] Create `src/camel_up/engine/__init__.py` and
       `src/camel_up/engine/state.py`. Add other semantic modules only when they
       gain real responsibilities.
-- [ ] Convert `Camel` and `Board` into typed dataclasses in `engine.state`.
+- [ ] Represent camel placement once through immutable, typed coordinates in
+      `engine.state`; derive board stacks rather than storing both forms.
 - [ ] Introduce a typed `GameState` that owns the board, camels, dice inventory,
       and other state needed to continue a game.
 - [ ] Document stack ordering and state mutation expectations in docstrings and
       tests.
 - [ ] Re-export only the state types intended for use outside `engine.state`.
-- [ ] Keep `components.py` as a temporary compatibility shim that re-exports
-      the package types.
+- [ ] Keep `components.py` as a temporary compatibility shim backed by an
+      isolated prototype adapter; do not expose mutable adapters from
+      `camel_up.engine`.
 - [ ] Update tests to import state types through `camel_up.engine`.
 
 Acceptance criteria:
 
-- Existing construction and board-placement behavior is preserved.
+- Existing construction and board-placement behavior is preserved through the
+  temporary CLI adapter.
 - `GameState` provides an explicit home for state currently held in module
   globals.
+- Engine states are immutable and hashable for safe branching and
+  transposition-table use.
 - `uv run camel-up` and all documented checks still pass.
 
 Review focus:

--- a/docs/software-foundation-plan.md
+++ b/docs/software-foundation-plan.md
@@ -52,7 +52,7 @@ Acceptance criteria:
 
 ## Phase 1: Package Structure (Immediate Next Step)
 
-Status: `Todo`
+Status: `Doing`
 
 Goal: Move from prototype root modules to a clean `src/` package layout with a
 semantic `engine` package. `engine` represents the deterministic Camel Up game
@@ -137,15 +137,15 @@ Shared-code policy:
 
 Tasks:
 
-- [ ] Create `src/camel_up/engine` with semantic modules rather than one large
+- [x] Create `src/camel_up/engine` with semantic modules rather than one large
       `board.py` or `rules.py`.
-- [ ] Replace the mutable `Camel` and `Board` state model with canonical engine
+- [x] Replace the mutable `Camel` and `Board` state model with canonical engine
       coordinates, retaining prototype adapters only while the CLI needs them.
-- [ ] Introduce `GameState` before adding more rule behavior.
+- [x] Introduce `GameState` before adding more rule behavior.
 - [ ] Put movement rules in `engine.movement`, dice rules in `engine.dice`,
       tile rules in `engine.tiles`, betting rules in `engine.betting`, and
       scoring rules in `engine.scoring`.
-- [ ] Re-export only stable public functions and dataclasses from
+- [x] Re-export only stable public functions and dataclasses from
       `camel_up.engine` or `camel_up.engine.api`.
 - [ ] Move gameplay orchestration out of root-level `main.py`.
 - [ ] Update CLI to call package APIs directly instead of using `runpy`.
@@ -171,6 +171,8 @@ runnable, and pass all documented checks.
 
 #### PR 1: `refactor: add engine state foundation`
 
+Status: `Done`
+
 Suggested branch: `chore/engine-state-foundation`
 
 Goal: Establish the engine package and typed state model without changing game
@@ -178,30 +180,39 @@ behavior.
 
 Tasks:
 
-- [ ] Create `src/camel_up/engine/__init__.py` and
+- [x] Create `src/camel_up/engine/__init__.py` and
       `src/camel_up/engine/state.py`. Add other semantic modules only when they
       gain real responsibilities.
-- [ ] Represent camel placement once through immutable, typed coordinates in
+- [x] Represent camel placement once through immutable, typed coordinates in
       `engine.state`; derive board stacks rather than storing both forms.
-- [ ] Introduce a typed `GameState` that owns the board, camels, dice inventory,
-      and other state needed to continue a game.
-- [ ] Document stack ordering and state mutation expectations in docstrings and
+- [x] Introduce a typed `GameState` foundation that owns the board and leg dice
+      inventory. Add player and betting state in focused follow-up pull
+      requests.
+- [x] Document stack ordering and state mutation expectations in docstrings and
       tests.
-- [ ] Re-export only the state types intended for use outside `engine.state`.
-- [ ] Keep `components.py` as a temporary compatibility shim backed by an
+- [x] Re-export only the state types intended for use outside `engine.state`.
+- [x] Keep `components.py` as a temporary compatibility shim backed by an
       isolated prototype adapter; do not expose mutable adapters from
       `camel_up.engine`.
-- [ ] Update tests to import state types through `camel_up.engine`.
+- [x] Update tests to import state types through `camel_up.engine`.
+
+Setup-state contract:
+
+- `GameState.pre_setup()` contains seven unplaced camels.
+- The deterministic setup transition introduced with dice rules will calculate
+  all starting positions and then construct one complete `BoardState`.
+- Individual setup rolls may be emitted as replay or UI events, but they are not
+  player decision points or intermediate engine states for agents and search.
 
 Acceptance criteria:
 
-- Existing construction and board-placement behavior is preserved through the
+- [x] Existing construction and board-placement behavior is preserved through the
   temporary CLI adapter.
-- `GameState` provides an explicit home for state currently held in module
+- [x] `GameState` provides an explicit home for state currently held in module
   globals.
-- Engine states are immutable and hashable for safe branching and
+- [x] Engine states are immutable and hashable for safe branching and
   transposition-table use.
-- `uv run camel-up` and all documented checks still pass.
+- [x] `uv run camel-up` and all documented checks still pass.
 
 Review focus:
 
@@ -276,9 +287,10 @@ Review focus:
 - Package boundaries, public API size, CLI behavior, and removal of legacy
   imports.
 
-The three pull requests do not include spectator tiles, betting, scoring, legal
-action masks, RL environments, or training code. Those remain in their
-corresponding later phases.
+The three pull requests do not include spectator tile actions or movement
+effects, betting, scoring, legal action masks, RL environments, or training
+code. PR 1 defines the typed spectator-tile state and board-level placement
+invariants only; the remaining behavior stays in its corresponding later phase.
 
 ## Phase 2: Tooling Baseline
 
@@ -314,8 +326,8 @@ game state and rule APIs.
 
 Tasks:
 
-- [ ] Represent engine state with dataclasses such as `Camel`, `Board`,
-      `GameState`, `DieRoll`, and `SpectatorTile`.
+- [ ] Represent engine state with dataclasses such as `CamelPosition`,
+      `BoardState`, `GameState`, `DieRoll`, `SpectatorTile`, and player state.
 - [ ] Inject or store `random.Random` instead of using global `random`.
 - [ ] Remove printing and user input from engine logic.
 - [ ] Make dice rolling deterministic under a fixed seed.
@@ -437,8 +449,9 @@ The recommended first milestone is intentionally small and starts with CI:
 
 - [x] Add `.github/workflows/ci.yml`.
 - [x] Verify the current documented checks pass in CI.
-- [ ] Create `src/camel_up/engine`.
-- [ ] Move `Camel` and `Board` into package modules.
+- [x] Create `src/camel_up/engine`.
+- [x] Add canonical `CamelPosition`, `BoardState`, and `GameState` types while
+      isolating the temporary mutable CLI adapter.
 - [ ] Update imports and CLI.
 - [ ] Expand Ruff and MyPy to check `src`.
 - [ ] Add focused tests for stack movement and deterministic dice rolling.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,9 @@ dev = [
 ]
 
 [tool.setuptools]
+package-dir = { camel_up = "src/camel_up" }
+packages = ["camel_up", "camel_up.cli", "camel_up.engine"]
 py-modules = ["components", "main"]
-
-[tool.setuptools.packages.find]
-where = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/camel_up/cli/legacy_components.py
+++ b/src/camel_up/cli/legacy_components.py
@@ -1,0 +1,84 @@
+"""Mutable prototype types retained until the CLI is migrated to engine APIs."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass, field
+
+LEGACY_DICE = ("red", "blue", "green", "yellow", "purple", "grey")
+
+
+@dataclass
+class Camel:
+    """Camel representation expected by the prototype CLI."""
+
+    color: str
+    block_id: int | None = None
+    stack_id: int | None = None
+
+
+@dataclass
+class Board:
+    """Mutable board adapter expected by the prototype CLI."""
+
+    land_len: int
+    blocks: list[list[Camel]] = field(init=False)
+    spectator_tiles: dict[int, str] = field(default_factory=dict, init=False)
+    dices: list[str] = field(default_factory=lambda: list(LEGACY_DICE), init=False)
+
+    def __post_init__(self) -> None:
+        """Create the requested number of empty spaces."""
+        self.blocks = [[] for _ in range(self.land_len)]
+
+    def toss_dice(self) -> tuple[str, int]:
+        """Remove and roll one of the dice still available this leg."""
+        die_index = random.randint(0, len(self.dices) - 1)
+        step = random.randint(1, 3)
+        return self.dices.pop(die_index), step
+
+    def place_camel(
+        self,
+        block_id: int,
+        camels: list[Camel],
+        forward: bool = True,
+    ) -> None:
+        """Place camels using the prototype's mutable stack behavior."""
+        if forward:
+            self.blocks[block_id].extend(camels)
+        else:
+            self.blocks[block_id] = camels + self.blocks[block_id]
+        self.update_camels(block_id)
+
+    def update_camels(self, block_id: int) -> None:
+        """Synchronize prototype camel coordinates for one space."""
+        for stack_id, camel in enumerate(self.blocks[block_id]):
+            camel.block_id = block_id
+            camel.stack_id = stack_id
+
+    def select_camel(self, camel: Camel) -> list[Camel]:
+        """Remove and return a camel and every camel above it."""
+        if camel.block_id is None or camel.stack_id is None:
+            raise ValueError("camel must be placed before it can be selected")
+        moving_stack = self.blocks[camel.block_id][camel.stack_id :]
+        self.blocks[camel.block_id] = self.blocks[camel.block_id][: camel.stack_id]
+        return moving_stack
+
+    def place_spectator_tile(self, block_id: int, side: str) -> None:
+        """Place a tile using the prototype's terminal feedback behavior."""
+        if self.blocks[block_id]:
+            print("Place your spectator tile into an empty space.")
+        elif (
+            block_id - 1 in self.spectator_tiles or block_id + 1 in self.spectator_tiles
+        ):
+            print(
+                "You are not allowed to place the spectator tile"
+                "onto a space that is adjacent to a space containing"
+                "a spectator tile."
+            )
+        else:
+            self.spectator_tiles[block_id] = side
+
+    def one_leg_reset(self) -> None:
+        """Reset the prototype's leg-scoped state."""
+        self.spectator_tiles = {}
+        self.dices[:] = LEGACY_DICE

--- a/src/camel_up/engine/__init__.py
+++ b/src/camel_up/engine/__init__.py
@@ -1,5 +1,29 @@
-"""Public state types for the Camel Up engine."""
+"""Stable public types and queries for the Camel Up engine."""
 
-from camel_up.engine.state import Board, Camel, GameState
+from camel_up.engine.state import (
+    CAMEL_ORDER,
+    DIE_ORDER,
+    BoardState,
+    CamelId,
+    CamelPosition,
+    DieId,
+    GameState,
+    SpectatorTile,
+    carried_camels,
+    position_of,
+    stack_at,
+)
 
-__all__ = ["Board", "Camel", "GameState"]
+__all__ = [
+    "CAMEL_ORDER",
+    "DIE_ORDER",
+    "BoardState",
+    "CamelId",
+    "CamelPosition",
+    "DieId",
+    "GameState",
+    "SpectatorTile",
+    "carried_camels",
+    "position_of",
+    "stack_at",
+]

--- a/src/camel_up/engine/__init__.py
+++ b/src/camel_up/engine/__init__.py
@@ -1,0 +1,5 @@
+"""Public state types for the Camel Up engine."""
+
+from camel_up.engine.state import Board, Camel, GameState
+
+__all__ = ["Board", "Camel", "GameState"]

--- a/src/camel_up/engine/state.py
+++ b/src/camel_up/engine/state.py
@@ -1,122 +1,197 @@
-"""Typed state containers for the Camel Up engine."""
+"""Canonical, immutable state containers for the Camel Up engine."""
 
 from __future__ import annotations
 
-import random
 from dataclasses import dataclass, field
+from typing import Literal, TypeAlias
 
-STANDARD_DICE = ("red", "blue", "green", "yellow", "purple", "grey")
+CamelId: TypeAlias = Literal[
+    "red",
+    "blue",
+    "green",
+    "yellow",
+    "purple",
+    "white",
+    "black",
+]
+DieId: TypeAlias = Literal[
+    "red",
+    "blue",
+    "green",
+    "yellow",
+    "purple",
+    "grey",
+]
+
+CAMEL_ORDER: tuple[CamelId, ...] = (
+    "red",
+    "blue",
+    "green",
+    "yellow",
+    "purple",
+    "white",
+    "black",
+)
+DIE_ORDER: tuple[DieId, ...] = (
+    "red",
+    "blue",
+    "green",
+    "yellow",
+    "purple",
+    "grey",
+)
 
 
-@dataclass
-class Camel:
-    """A camel and its current board position.
+@dataclass(frozen=True, slots=True)
+class CamelPosition:
+    """A camel's coordinate on the track and within its stack.
 
-    ``stack_id`` is the camel's zero-based index in a board space. Index zero
-    is the bottom of a stack and the last index is the top.
+    Level zero is the bottom of a stack. An unplaced camel has both fields set
+    to ``None``. Positions are the sole source of truth for camel placement;
+    board stacks are derived from them.
     """
 
-    color: str
-    block_id: int | None = None
-    stack_id: int | None = None
+    space: int | None = None
+    level: int | None = None
+
+    def __post_init__(self) -> None:
+        """Require a complete placed or unplaced coordinate."""
+        if (self.space is None) != (self.level is None):
+            raise ValueError("space and level must either both be set or both be None")
+        if self.space is not None and self.space < 0:
+            raise ValueError("space must be non-negative")
+        if self.level is not None and self.level < 0:
+            raise ValueError("level must be non-negative")
+
+    @property
+    def is_placed(self) -> bool:
+        """Return whether the camel is currently on the board."""
+        return self.space is not None
 
 
-@dataclass
-class Board:
-    """Mutable board state used by the prototype game loop.
+@dataclass(frozen=True, slots=True)
+class SpectatorTile:
+    """A player's spectator tile and its movement effect."""
 
-    Each entry in ``blocks`` is ordered from the bottom of its camel stack to
-    the top. Board methods mutate both the stacks and the position fields on
-    affected camels so those two representations remain consistent.
+    player_id: int
+    space: int
+    effect: Literal[-1, 1]
+
+    def __post_init__(self) -> None:
+        """Validate the state-independent parts of a tile coordinate."""
+        if self.player_id < 0:
+            raise ValueError("player_id must be non-negative")
+        if self.space < 0:
+            raise ValueError("space must be non-negative")
+        if self.effect not in (-1, 1):
+            raise ValueError("effect must be -1 or 1")
+
+
+def _initial_camel_positions() -> tuple[CamelPosition, ...]:
+    """Return one unplaced coordinate for each camel."""
+    return tuple(CamelPosition() for _ in CAMEL_ORDER)
+
+
+@dataclass(frozen=True, slots=True)
+class BoardState:
+    """Immutable track state with camel coordinates and spectator tiles.
+
+    ``camel_positions`` uses :data:`CAMEL_ORDER`; its index is the camel's
+    identity. Camels on the same space must occupy unique, contiguous levels
+    beginning at zero.
     """
 
-    land_len: int
-    blocks: list[list[Camel]] = field(init=False)
-    spectator_tiles: dict[int, str] = field(default_factory=dict, init=False)
-    dices: list[str] = field(
-        default_factory=lambda: list(STANDARD_DICE),
-        init=False,
+    track_length: int = 17
+    camel_positions: tuple[CamelPosition, ...] = field(
+        default_factory=_initial_camel_positions
     )
+    spectator_tiles: tuple[SpectatorTile, ...] = ()
 
     def __post_init__(self) -> None:
-        """Create the requested number of empty board spaces."""
-        self.blocks = [[] for _ in range(self.land_len)]
+        """Validate coordinates and canonical tile ordering."""
+        if self.track_length <= 0:
+            raise ValueError("track_length must be positive")
+        if len(self.camel_positions) != len(CAMEL_ORDER):
+            raise ValueError(f"camel_positions must contain {len(CAMEL_ORDER)} entries")
 
-    def toss_dice(self) -> tuple[str, int]:
-        """Remove and roll one of the dice still available this leg."""
-        die_index = random.randint(0, len(self.dices) - 1)
-        step = random.randint(1, 3)
-        return self.dices.pop(die_index), step
+        levels_by_space: dict[int, list[int]] = {}
+        for position in self.camel_positions:
+            if not position.is_placed:
+                continue
+            assert position.space is not None
+            assert position.level is not None
+            if position.space >= self.track_length:
+                raise ValueError("camel space must be within the track")
+            levels_by_space.setdefault(position.space, []).append(position.level)
 
-    def place_camel(
-        self,
-        block_id: int,
-        camels: list[Camel],
-        forward: bool = True,
-    ) -> None:
-        """Place a camel stack on a space and update its positions.
+        for levels in levels_by_space.values():
+            if sorted(levels) != list(range(len(levels))):
+                raise ValueError("stack levels must be unique and contiguous from zero")
 
-        Forward-moving camels land on top of the existing stack. Backward-
-        moving camels are placed underneath it. The order within ``camels`` is
-        preserved in both cases.
-        """
-        if forward:
-            self.blocks[block_id].extend(camels)
-        else:
-            self.blocks[block_id] = camels + self.blocks[block_id]
+        player_ids = [tile.player_id for tile in self.spectator_tiles]
+        if player_ids != sorted(player_ids) or len(player_ids) != len(set(player_ids)):
+            raise ValueError("spectator tiles must be unique and ordered by player_id")
 
-        self.update_camels(block_id)
-
-    def update_camels(self, block_id: int) -> None:
-        """Synchronize camel position fields for one board space."""
-        for stack_id, camel in enumerate(self.blocks[block_id]):
-            camel.block_id = block_id
-            camel.stack_id = stack_id
-
-    def select_camel(self, camel: Camel) -> list[Camel]:
-        """Remove and return ``camel`` and every camel above it."""
-        if camel.block_id is None or camel.stack_id is None:
-            raise ValueError("camel must be placed before it can be selected")
-
-        moving_stack = self.blocks[camel.block_id][camel.stack_id :]
-        self.blocks[camel.block_id] = self.blocks[camel.block_id][: camel.stack_id]
-        return moving_stack
-
-    def place_spectator_tile(self, block_id: int, side: str) -> None:
-        """Place a spectator tile when the prototype placement rules allow it."""
-        if self.blocks[block_id]:
-            print("Place your spectator tile into an empty space.")
-        elif (
-            block_id - 1 in self.spectator_tiles
-            or block_id + 1 in self.spectator_tiles
-        ):
-            print(
-                "You are not allowed to place the spectator tile"
-                "onto a space that is adjacent to a space containing"
-                "a spectator tile."
-            )
-        else:
-            self.spectator_tiles[block_id] = side
-
-    def one_leg_reset(self) -> None:
-        """Restore the prototype state reset at the end of a leg."""
-        self.spectator_tiles = {}
-        self.dices[:] = STANDARD_DICE
+        tile_spaces = [tile.space for tile in self.spectator_tiles]
+        if len(tile_spaces) != len(set(tile_spaces)):
+            raise ValueError("spectator tiles cannot share a space")
+        if any(space >= self.track_length for space in tile_spaces):
+            raise ValueError("spectator tile space must be within the track")
 
 
-@dataclass
+@dataclass(frozen=True, slots=True)
 class GameState:
-    """State required to pause and continue a game.
+    """Complete public state boundary for deterministic engine transitions.
 
-    ``dice_inventory`` is the same mutable list exposed as ``board.dices``.
-    Keeping one shared list preserves the prototype API while making ownership
-    explicit at the game-state boundary.
+    The state contains no random generator and exposes no mutation methods.
+    Rule functions receive a state and return a replacement state atomically,
+    which makes states safe to compare, hash, replay, and store in search trees.
     """
 
-    board: Board
-    camels: dict[str, Camel] = field(default_factory=dict)
-    dice_inventory: list[str] = field(init=False)
+    board: BoardState = field(default_factory=BoardState)
+    remaining_dice: tuple[DieId, ...] = DIE_ORDER
+    current_player: int = 0
+    leg_number: int = 1
+    terminal: bool = False
 
     def __post_init__(self) -> None:
-        """Link the game-level dice inventory to the compatibility board API."""
-        self.dice_inventory = self.board.dices
+        """Validate canonical dice order and scalar state fields."""
+        if len(self.remaining_dice) != len(set(self.remaining_dice)):
+            raise ValueError("remaining_dice cannot contain duplicates")
+        expected_order = tuple(
+            die for die in DIE_ORDER if die in self.remaining_dice
+        )
+        if self.remaining_dice != expected_order:
+            raise ValueError("remaining_dice must be valid and use canonical order")
+        if self.current_player < 0:
+            raise ValueError("current_player must be non-negative")
+        if self.leg_number < 1:
+            raise ValueError("leg_number must be positive")
+
+
+def position_of(state: GameState, camel: CamelId) -> CamelPosition:
+    """Return the authoritative coordinate for ``camel``."""
+    return state.board.camel_positions[CAMEL_ORDER.index(camel)]
+
+
+def stack_at(state: GameState, space: int) -> tuple[CamelId, ...]:
+    """Return the stack at ``space`` ordered from bottom to top."""
+    if not 0 <= space < state.board.track_length:
+        raise ValueError("space must be within the track")
+
+    stack: list[tuple[int, CamelId]] = []
+    for camel, position in zip(CAMEL_ORDER, state.board.camel_positions):
+        if position.space == space:
+            assert position.level is not None
+            stack.append((position.level, camel))
+    return tuple(camel for _, camel in sorted(stack))
+
+
+def carried_camels(state: GameState, camel: CamelId) -> tuple[CamelId, ...]:
+    """Return ``camel`` and every camel above it, bottom to top."""
+    position = position_of(state, camel)
+    if not position.is_placed:
+        raise ValueError("camel must be placed before it can carry a stack")
+    assert position.space is not None
+    assert position.level is not None
+    return stack_at(state, position.space)[position.level :]

--- a/src/camel_up/engine/state.py
+++ b/src/camel_up/engine/state.py
@@ -89,7 +89,8 @@ class BoardState:
 
     ``camel_positions`` uses :data:`CAMEL_ORDER`; its index is the camel's
     identity. Camels on the same space must occupy unique, contiguous levels
-    beginning at zero.
+    beginning at zero. ``spectator_tiles`` is ordered by ``player_id`` so that
+    logically equivalent snapshots compare and hash identically.
     """
 
     track_length: int
@@ -116,24 +117,31 @@ class BoardState:
         if len(self.camel_positions) != len(CAMEL_ORDER):
             raise ValueError(f"camel_positions must contain {len(CAMEL_ORDER)} entries")
 
-        self._validate_camel_positions()
-        self._validate_spectator_tiles()
+        occupied_spaces = self._validate_camel_positions()
+        self._validate_spectator_tiles(occupied_spaces)
 
-    def _validate_camel_positions(self) -> None:
+    def _validate_camel_positions(self) -> set[int]:
         """Validate track coordinates and stack invariants."""
         levels_by_space: dict[int, list[int]] = {}
+        placed_count = 0
         for position in self.camel_positions:
             if position.space is None or position.level is None:
                 continue
+            placed_count += 1
             if position.space >= self.track_length:
                 raise ValueError("camel space must be within the track")
             levels_by_space.setdefault(position.space, []).append(position.level)
+
+        if placed_count not in (0, len(CAMEL_ORDER)):
+            raise ValueError("camels must be either all unplaced or all placed")
 
         for levels in levels_by_space.values():
             if sorted(levels) != list(range(len(levels))):
                 raise ValueError("stack levels must be unique and contiguous from zero")
 
-    def _validate_spectator_tiles(self) -> None:
+        return set(levels_by_space)
+
+    def _validate_spectator_tiles(self, occupied_spaces: set[int]) -> None:
         """Validate tiles for initial and populated mid-game snapshots."""
         player_ids = [tile.player_id for tile in self.spectator_tiles]
         if player_ids != sorted(player_ids) or len(player_ids) != len(set(player_ids)):
@@ -144,6 +152,19 @@ class BoardState:
             raise ValueError("spectator tiles cannot share a space")
         if any(space >= self.track_length for space in tile_spaces):
             raise ValueError("spectator tile space must be within the track")
+        if 0 in tile_spaces:
+            raise ValueError("spectator tiles cannot be placed on track space 1")
+        if occupied_spaces.intersection(tile_spaces):
+            raise ValueError("spectator tiles cannot share a space with camels")
+
+        sorted_spaces = sorted(tile_spaces)
+        if any(
+            right_space - left_space == 1
+            for left_space, right_space in zip(
+                sorted_spaces, sorted_spaces[1:], strict=False
+            )
+        ):
+            raise ValueError("spectator tiles cannot be on adjacent spaces")
 
 
 @dataclass(frozen=True, slots=True)
@@ -170,9 +191,7 @@ class GameState:
         """Validate canonical dice order and scalar state fields."""
         if len(self.remaining_dice) != len(set(self.remaining_dice)):
             raise ValueError("remaining_dice cannot contain duplicates")
-        expected_order = tuple(
-            die for die in DIE_ORDER if die in self.remaining_dice
-        )
+        expected_order = tuple(die for die in DIE_ORDER if die in self.remaining_dice)
         if self.remaining_dice != expected_order:
             raise ValueError("remaining_dice must be valid and use canonical order")
         if self.current_player < 0:
@@ -192,7 +211,7 @@ def stack_at(board: BoardState, space: int) -> tuple[CamelId, ...]:
         raise ValueError("space must be within the track")
 
     stack: list[tuple[int, CamelId]] = []
-    for camel, position in zip(CAMEL_ORDER, board.camel_positions):
+    for camel, position in zip(CAMEL_ORDER, board.camel_positions, strict=True):
         if position.space == space and position.level is not None:
             stack.append((position.level, camel))
     return tuple(camel for _, camel in sorted(stack))

--- a/src/camel_up/engine/state.py
+++ b/src/camel_up/engine/state.py
@@ -181,26 +181,26 @@ class GameState:
             raise ValueError("leg_number must be positive")
 
 
-def position_of(state: GameState, camel: CamelId) -> CamelPosition:
+def position_of(board: BoardState, camel: CamelId) -> CamelPosition:
     """Return the authoritative coordinate for ``camel``."""
-    return state.board.camel_positions[_CAMEL_INDEX[camel]]
+    return board.camel_positions[_CAMEL_INDEX[camel]]
 
 
-def stack_at(state: GameState, space: int) -> tuple[CamelId, ...]:
+def stack_at(board: BoardState, space: int) -> tuple[CamelId, ...]:
     """Return the stack at ``space`` ordered from bottom to top."""
-    if not 0 <= space < state.board.track_length:
+    if not 0 <= space < board.track_length:
         raise ValueError("space must be within the track")
 
     stack: list[tuple[int, CamelId]] = []
-    for camel, position in zip(CAMEL_ORDER, state.board.camel_positions):
+    for camel, position in zip(CAMEL_ORDER, board.camel_positions):
         if position.space == space and position.level is not None:
             stack.append((position.level, camel))
     return tuple(camel for _, camel in sorted(stack))
 
 
-def carried_camels(state: GameState, camel: CamelId) -> tuple[CamelId, ...]:
+def carried_camels(board: BoardState, camel: CamelId) -> tuple[CamelId, ...]:
     """Return ``camel`` and every camel above it, bottom to top."""
-    position = position_of(state, camel)
+    position = position_of(board, camel)
     if position.space is None or position.level is None:
         raise ValueError("camel must be placed before it can carry a stack")
-    return stack_at(state, position.space)[position.level :]
+    return stack_at(board, position.space)[position.level :]

--- a/src/camel_up/engine/state.py
+++ b/src/camel_up/engine/state.py
@@ -1,0 +1,122 @@
+"""Typed state containers for the Camel Up engine."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass, field
+
+STANDARD_DICE = ("red", "blue", "green", "yellow", "purple", "grey")
+
+
+@dataclass
+class Camel:
+    """A camel and its current board position.
+
+    ``stack_id`` is the camel's zero-based index in a board space. Index zero
+    is the bottom of a stack and the last index is the top.
+    """
+
+    color: str
+    block_id: int | None = None
+    stack_id: int | None = None
+
+
+@dataclass
+class Board:
+    """Mutable board state used by the prototype game loop.
+
+    Each entry in ``blocks`` is ordered from the bottom of its camel stack to
+    the top. Board methods mutate both the stacks and the position fields on
+    affected camels so those two representations remain consistent.
+    """
+
+    land_len: int
+    blocks: list[list[Camel]] = field(init=False)
+    spectator_tiles: dict[int, str] = field(default_factory=dict, init=False)
+    dices: list[str] = field(
+        default_factory=lambda: list(STANDARD_DICE),
+        init=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Create the requested number of empty board spaces."""
+        self.blocks = [[] for _ in range(self.land_len)]
+
+    def toss_dice(self) -> tuple[str, int]:
+        """Remove and roll one of the dice still available this leg."""
+        die_index = random.randint(0, len(self.dices) - 1)
+        step = random.randint(1, 3)
+        return self.dices.pop(die_index), step
+
+    def place_camel(
+        self,
+        block_id: int,
+        camels: list[Camel],
+        forward: bool = True,
+    ) -> None:
+        """Place a camel stack on a space and update its positions.
+
+        Forward-moving camels land on top of the existing stack. Backward-
+        moving camels are placed underneath it. The order within ``camels`` is
+        preserved in both cases.
+        """
+        if forward:
+            self.blocks[block_id].extend(camels)
+        else:
+            self.blocks[block_id] = camels + self.blocks[block_id]
+
+        self.update_camels(block_id)
+
+    def update_camels(self, block_id: int) -> None:
+        """Synchronize camel position fields for one board space."""
+        for stack_id, camel in enumerate(self.blocks[block_id]):
+            camel.block_id = block_id
+            camel.stack_id = stack_id
+
+    def select_camel(self, camel: Camel) -> list[Camel]:
+        """Remove and return ``camel`` and every camel above it."""
+        if camel.block_id is None or camel.stack_id is None:
+            raise ValueError("camel must be placed before it can be selected")
+
+        moving_stack = self.blocks[camel.block_id][camel.stack_id :]
+        self.blocks[camel.block_id] = self.blocks[camel.block_id][: camel.stack_id]
+        return moving_stack
+
+    def place_spectator_tile(self, block_id: int, side: str) -> None:
+        """Place a spectator tile when the prototype placement rules allow it."""
+        if self.blocks[block_id]:
+            print("Place your spectator tile into an empty space.")
+        elif (
+            block_id - 1 in self.spectator_tiles
+            or block_id + 1 in self.spectator_tiles
+        ):
+            print(
+                "You are not allowed to place the spectator tile"
+                "onto a space that is adjacent to a space containing"
+                "a spectator tile."
+            )
+        else:
+            self.spectator_tiles[block_id] = side
+
+    def one_leg_reset(self) -> None:
+        """Restore the prototype state reset at the end of a leg."""
+        self.spectator_tiles = {}
+        self.dices[:] = STANDARD_DICE
+
+
+@dataclass
+class GameState:
+    """State required to pause and continue a game.
+
+    ``dice_inventory`` is the same mutable list exposed as ``board.dices``.
+    Keeping one shared list preserves the prototype API while making ownership
+    explicit at the game-state boundary.
+    """
+
+    board: Board
+    camels: dict[str, Camel] = field(default_factory=dict)
+    dice_inventory: list[str] = field(init=False)
+
+    def __post_init__(self) -> None:
+        """Link the game-level dice inventory to the compatibility board API."""
+        self.dice_inventory = self.board.dices

--- a/src/camel_up/engine/state.py
+++ b/src/camel_up/engine/state.py
@@ -2,43 +2,39 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Literal, TypeAlias
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+from typing import Final, Literal
 
-CamelId: TypeAlias = Literal[
-    "red",
-    "blue",
-    "green",
-    "yellow",
-    "purple",
-    "white",
-    "black",
-]
-DieId: TypeAlias = Literal[
-    "red",
-    "blue",
-    "green",
-    "yellow",
-    "purple",
-    "grey",
-]
 
-CAMEL_ORDER: tuple[CamelId, ...] = (
-    "red",
-    "blue",
-    "green",
-    "yellow",
-    "purple",
-    "white",
-    "black",
-)
-DIE_ORDER: tuple[DieId, ...] = (
-    "red",
-    "blue",
-    "green",
-    "yellow",
-    "purple",
-    "grey",
+class CamelId(str, Enum):
+    """Stable identities for the five racing and two crazy camels."""
+
+    RED = "red"
+    BLUE = "blue"
+    GREEN = "green"
+    YELLOW = "yellow"
+    PURPLE = "purple"
+    WHITE = "white"
+    BLACK = "black"
+
+
+class DieId(str, Enum):
+    """Stable identities for the dice available during a leg."""
+
+    RED = "red"
+    BLUE = "blue"
+    GREEN = "green"
+    YELLOW = "yellow"
+    PURPLE = "purple"
+    GREY = "grey"
+
+
+CAMEL_ORDER: Final = tuple(CamelId)
+DIE_ORDER: Final = tuple(DieId)
+_CAMEL_INDEX: Final = MappingProxyType(
+    {camel: index for index, camel in enumerate(CAMEL_ORDER)}
 )
 
 
@@ -87,11 +83,6 @@ class SpectatorTile:
             raise ValueError("effect must be -1 or 1")
 
 
-def _initial_camel_positions() -> tuple[CamelPosition, ...]:
-    """Return one unplaced coordinate for each camel."""
-    return tuple(CamelPosition() for _ in CAMEL_ORDER)
-
-
 @dataclass(frozen=True, slots=True)
 class BoardState:
     """Immutable track state with camel coordinates and spectator tiles.
@@ -101,25 +92,39 @@ class BoardState:
     beginning at zero.
     """
 
-    track_length: int = 17
-    camel_positions: tuple[CamelPosition, ...] = field(
-        default_factory=_initial_camel_positions
-    )
+    track_length: int
+    camel_positions: tuple[CamelPosition, ...]
     spectator_tiles: tuple[SpectatorTile, ...] = ()
 
+    @classmethod
+    def empty(cls, track_length: int = 17) -> BoardState:
+        """Create the deterministic board state before initial dice rolls.
+
+        Starting camel positions depend on random die outcomes. The seeded
+        setup transition will place them; state construction itself performs
+        no random work.
+        """
+        return cls(
+            track_length=track_length,
+            camel_positions=tuple(CamelPosition() for _ in CAMEL_ORDER),
+        )
+
     def __post_init__(self) -> None:
-        """Validate coordinates and canonical tile ordering."""
+        """Validate every newly constructed initial or mid-game snapshot."""
         if self.track_length <= 0:
             raise ValueError("track_length must be positive")
         if len(self.camel_positions) != len(CAMEL_ORDER):
             raise ValueError(f"camel_positions must contain {len(CAMEL_ORDER)} entries")
 
+        self._validate_camel_positions()
+        self._validate_spectator_tiles()
+
+    def _validate_camel_positions(self) -> None:
+        """Validate track coordinates and stack invariants."""
         levels_by_space: dict[int, list[int]] = {}
         for position in self.camel_positions:
-            if not position.is_placed:
+            if position.space is None or position.level is None:
                 continue
-            assert position.space is not None
-            assert position.level is not None
             if position.space >= self.track_length:
                 raise ValueError("camel space must be within the track")
             levels_by_space.setdefault(position.space, []).append(position.level)
@@ -128,6 +133,8 @@ class BoardState:
             if sorted(levels) != list(range(len(levels))):
                 raise ValueError("stack levels must be unique and contiguous from zero")
 
+    def _validate_spectator_tiles(self) -> None:
+        """Validate tiles for initial and populated mid-game snapshots."""
         player_ids = [tile.player_id for tile in self.spectator_tiles]
         if player_ids != sorted(player_ids) or len(player_ids) != len(set(player_ids)):
             raise ValueError("spectator tiles must be unique and ordered by player_id")
@@ -141,18 +148,23 @@ class BoardState:
 
 @dataclass(frozen=True, slots=True)
 class GameState:
-    """Complete public state boundary for deterministic engine transitions.
+    """Public state foundation for deterministic engine transitions.
 
     The state contains no random generator and exposes no mutation methods.
     Rule functions receive a state and return a replacement state atomically,
     which makes states safe to compare, hash, replay, and store in search trees.
     """
 
-    board: BoardState = field(default_factory=BoardState)
+    board: BoardState
     remaining_dice: tuple[DieId, ...] = DIE_ORDER
     current_player: int = 0
     leg_number: int = 1
     terminal: bool = False
+
+    @classmethod
+    def pre_setup(cls, track_length: int = 17) -> GameState:
+        """Create a state awaiting seeded initial camel placement."""
+        return cls(board=BoardState.empty(track_length))
 
     def __post_init__(self) -> None:
         """Validate canonical dice order and scalar state fields."""
@@ -171,7 +183,7 @@ class GameState:
 
 def position_of(state: GameState, camel: CamelId) -> CamelPosition:
     """Return the authoritative coordinate for ``camel``."""
-    return state.board.camel_positions[CAMEL_ORDER.index(camel)]
+    return state.board.camel_positions[_CAMEL_INDEX[camel]]
 
 
 def stack_at(state: GameState, space: int) -> tuple[CamelId, ...]:
@@ -181,8 +193,7 @@ def stack_at(state: GameState, space: int) -> tuple[CamelId, ...]:
 
     stack: list[tuple[int, CamelId]] = []
     for camel, position in zip(CAMEL_ORDER, state.board.camel_positions):
-        if position.space == space:
-            assert position.level is not None
+        if position.space == space and position.level is not None:
             stack.append((position.level, camel))
     return tuple(camel for _, camel in sorted(stack))
 
@@ -190,8 +201,6 @@ def stack_at(state: GameState, space: int) -> tuple[CamelId, ...]:
 def carried_camels(state: GameState, camel: CamelId) -> tuple[CamelId, ...]:
     """Return ``camel`` and every camel above it, bottom to top."""
     position = position_of(state, camel)
-    if not position.is_placed:
+    if position.space is None or position.level is None:
         raise ValueError("camel must be placed before it can carry a stack")
-    assert position.space is not None
-    assert position.level is not None
     return stack_at(state, position.space)[position.level :]

--- a/src/camel_up/engine/state.py
+++ b/src/camel_up/engine/state.py
@@ -90,7 +90,9 @@ class BoardState:
     ``camel_positions`` uses :data:`CAMEL_ORDER`; its index is the camel's
     identity. Camels on the same space must occupy unique, contiguous levels
     beginning at zero. ``spectator_tiles`` is ordered by ``player_id`` so that
-    logically equivalent snapshots compare and hash identically.
+    logically equivalent snapshots compare and hash identically. A snapshot
+    contains either no placed camels before setup or all camels after setup;
+    initial placement is committed as one atomic state transition.
     """
 
     track_length: int
@@ -101,9 +103,10 @@ class BoardState:
     def empty(cls, track_length: int = 17) -> BoardState:
         """Create the deterministic board state before initial dice rolls.
 
-        Starting camel positions depend on random die outcomes. The seeded
-        setup transition will place them; state construction itself performs
-        no random work.
+        Starting camel positions depend on random die outcomes. The future
+        seeded setup transition will calculate every position before creating
+        the next snapshot, so individual setup rolls do not expose partially
+        placed board states.
         """
         return cls(
             track_length=track_length,
@@ -121,7 +124,7 @@ class BoardState:
         self._validate_spectator_tiles(occupied_spaces)
 
     def _validate_camel_positions(self) -> set[int]:
-        """Validate track coordinates and stack invariants."""
+        """Validate camel coordinates and return occupied track spaces."""
         levels_by_space: dict[int, list[int]] = {}
         placed_count = 0
         for position in self.camel_positions:
@@ -139,7 +142,8 @@ class BoardState:
             if sorted(levels) != list(range(len(levels))):
                 raise ValueError("stack levels must be unique and contiguous from zero")
 
-        return set(levels_by_space)
+        occupied_spaces = set(levels_by_space)
+        return occupied_spaces
 
     def _validate_spectator_tiles(self, occupied_spaces: set[int]) -> None:
         """Validate tiles for initial and populated mid-game snapshots."""

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -1,0 +1,97 @@
+from camel_up.engine import Board, Camel, GameState
+
+
+def test_board_initializes_with_expected_spaces_and_dice() -> None:
+    board = Board(land_len=17)
+
+    assert len(board.blocks) == 17
+    assert board.dices == ["red", "blue", "green", "yellow", "purple", "grey"]
+
+
+def test_camel_can_be_constructed_with_position() -> None:
+    camel = Camel(color="red", block_id=0, stack_id=0)
+
+    assert camel.color == "red"
+    assert camel.block_id == 0
+    assert camel.stack_id == 0
+
+
+def test_forward_placement_preserves_bottom_to_top_order() -> None:
+    board = Board(land_len=17)
+    red = Camel("red")
+    blue = Camel("blue")
+    green = Camel("green")
+
+    board.place_camel(2, [red])
+    board.place_camel(2, [blue, green])
+
+    assert board.blocks[2] == [red, blue, green]
+    assert [(camel.block_id, camel.stack_id) for camel in board.blocks[2]] == [
+        (2, 0),
+        (2, 1),
+        (2, 2),
+    ]
+
+
+def test_backward_placement_puts_moving_stack_under_existing_camels() -> None:
+    board = Board(land_len=17)
+    red = Camel("red")
+    blue = Camel("blue")
+    green = Camel("green")
+
+    board.place_camel(2, [green])
+    board.place_camel(2, [red, blue], forward=False)
+
+    assert board.blocks[2] == [red, blue, green]
+    assert [(camel.block_id, camel.stack_id) for camel in board.blocks[2]] == [
+        (2, 0),
+        (2, 1),
+        (2, 2),
+    ]
+
+
+def test_select_camel_returns_it_and_every_camel_above() -> None:
+    board = Board(land_len=17)
+    red = Camel("red")
+    blue = Camel("blue")
+    green = Camel("green")
+    board.place_camel(2, [red, blue, green])
+
+    moving_stack = board.select_camel(blue)
+
+    assert moving_stack == [blue, green]
+    assert board.blocks[2] == [red]
+
+
+def test_game_state_owns_camels_and_current_dice_inventory() -> None:
+    board = Board(land_len=17)
+    red = Camel("red")
+    state = GameState(board=board, camels={"red": red})
+
+    assert state.board is board
+    assert state.camels == {"red": red}
+    assert state.dice_inventory is board.dices
+
+    board.toss_dice()
+
+    assert len(state.dice_inventory) == 5
+
+    board.one_leg_reset()
+
+    assert state.dice_inventory is board.dices
+    assert state.dice_inventory == [
+        "red",
+        "blue",
+        "green",
+        "yellow",
+        "purple",
+        "grey",
+    ]
+
+
+def test_legacy_components_module_re_exports_engine_types() -> None:
+    from components import Board as LegacyBoard
+    from components import Camel as LegacyCamel
+
+    assert LegacyBoard is Board
+    assert LegacyCamel is Camel

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -17,31 +17,53 @@ from camel_up.engine import (
 )
 
 
-def test_identifier_orders_are_derived_from_enum_declarations() -> None:
-    assert tuple(CamelId) == CAMEL_ORDER
-    assert tuple(DieId) == DIE_ORDER
+def _fully_placed_positions() -> tuple[CamelPosition, ...]:
+    return tuple(
+        CamelPosition(space=10 + index, level=0) for index in range(len(CAMEL_ORDER))
+    )
+
+
+def test_identifier_orders_are_stable_engine_contracts() -> None:
+    expected_camel_order = (
+        CamelId.RED,
+        CamelId.BLUE,
+        CamelId.GREEN,
+        CamelId.YELLOW,
+        CamelId.PURPLE,
+        CamelId.WHITE,
+        CamelId.BLACK,
+    )
+    expected_die_order = (
+        DieId.RED,
+        DieId.BLUE,
+        DieId.GREEN,
+        DieId.YELLOW,
+        DieId.PURPLE,
+        DieId.GREY,
+    )
+
+    assert tuple(CAMEL_ORDER) == expected_camel_order
+    assert tuple(DIE_ORDER) == expected_die_order
 
 
 def test_pre_setup_game_has_one_unplaced_position_per_camel() -> None:
     state = GameState.pre_setup()
+    expected_positions = tuple(CamelPosition() for _ in CAMEL_ORDER)
 
     assert state.board.track_length == 17
-    assert len(state.board.camel_positions) == len(CAMEL_ORDER)
-    assert all(not position.is_placed for position in state.board.camel_positions)
+    assert state.board.camel_positions == expected_positions
     assert state.remaining_dice == DIE_ORDER
 
 
 def test_coordinates_are_the_only_source_for_derived_stack_order() -> None:
-    positions = (
+    positions = list(_fully_placed_positions())
+    positions[:4] = (
         CamelPosition(space=4, level=0),
         CamelPosition(space=4, level=2),
         CamelPosition(space=4, level=1),
         CamelPosition(space=7, level=0),
-        CamelPosition(),
-        CamelPosition(space=15, level=0),
-        CamelPosition(space=16, level=0),
     )
-    board = BoardState(track_length=17, camel_positions=positions)
+    board = BoardState(track_length=17, camel_positions=tuple(positions))
 
     assert stack_at(board, 4) == (
         CamelId.RED,
@@ -76,12 +98,19 @@ def test_unplaced_camel_cannot_carry_a_stack() -> None:
 def test_board_rejects_duplicate_or_non_contiguous_stack_levels(
     positions: tuple[CamelPosition, CamelPosition],
 ) -> None:
-    padded_positions = positions + tuple(
-        CamelPosition() for _ in range(len(CAMEL_ORDER) - len(positions))
-    )
+    all_positions = list(_fully_placed_positions())
+    all_positions[:2] = positions
 
     with pytest.raises(ValueError, match="unique and contiguous"):
-        BoardState(track_length=17, camel_positions=padded_positions)
+        BoardState(track_length=17, camel_positions=tuple(all_positions))
+
+
+def test_board_rejects_partial_camel_setup() -> None:
+    positions = list(BoardState.empty().camel_positions)
+    positions[0] = CamelPosition(space=2, level=0)
+
+    with pytest.raises(ValueError, match="either all unplaced or all placed"):
+        BoardState(track_length=17, camel_positions=tuple(positions))
 
 
 def test_position_requires_both_coordinate_fields() -> None:
@@ -98,14 +127,15 @@ def test_spectator_tiles_have_canonical_player_order() -> None:
     with pytest.raises(ValueError, match="ordered by player_id"):
         BoardState(
             track_length=17,
-            camel_positions=BoardState.empty().camel_positions,
+            camel_positions=_fully_placed_positions(),
             spectator_tiles=tiles,
         )
 
 
-def test_board_validates_populated_mid_game_tile_snapshots() -> None:
-    board = replace(
-        BoardState.empty(),
+def test_board_accepts_populated_mid_game_tile_snapshot() -> None:
+    board = BoardState(
+        track_length=17,
+        camel_positions=_fully_placed_positions(),
         spectator_tiles=(
             SpectatorTile(player_id=0, space=3, effect=-1),
             SpectatorTile(player_id=1, space=5, effect=1),
@@ -114,14 +144,57 @@ def test_board_validates_populated_mid_game_tile_snapshots() -> None:
 
     assert [tile.space for tile in board.spectator_tiles] == [3, 5]
 
+
+def test_board_rejects_spectator_tiles_sharing_a_space() -> None:
     with pytest.raises(ValueError, match="cannot share a space"):
-        replace(
-            board,
+        BoardState(
+            track_length=17,
+            camel_positions=_fully_placed_positions(),
             spectator_tiles=(
                 SpectatorTile(player_id=0, space=3, effect=-1),
                 SpectatorTile(player_id=1, space=3, effect=1),
             ),
         )
+
+
+def test_board_rejects_spectator_tile_on_track_space_one() -> None:
+    with pytest.raises(ValueError, match="track space 1"):
+        BoardState(
+            track_length=17,
+            camel_positions=_fully_placed_positions(),
+            spectator_tiles=(SpectatorTile(player_id=0, space=0, effect=1),),
+        )
+
+
+def test_board_rejects_spectator_tile_on_a_camel_space() -> None:
+    with pytest.raises(ValueError, match="space with camels"):
+        BoardState(
+            track_length=17,
+            camel_positions=_fully_placed_positions(),
+            spectator_tiles=(SpectatorTile(player_id=0, space=10, effect=1),),
+        )
+
+
+def test_board_rejects_spectator_tiles_on_adjacent_spaces() -> None:
+    with pytest.raises(ValueError, match="adjacent spaces"):
+        BoardState(
+            track_length=17,
+            camel_positions=_fully_placed_positions(),
+            spectator_tiles=(
+                SpectatorTile(player_id=0, space=3, effect=-1),
+                SpectatorTile(player_id=1, space=4, effect=1),
+            ),
+        )
+
+
+def test_board_allows_spectator_tile_adjacent_to_a_camel() -> None:
+    board = BoardState(
+        track_length=17,
+        camel_positions=_fully_placed_positions(),
+        spectator_tiles=(SpectatorTile(player_id=0, space=9, effect=1),),
+    )
+
+    assert board.spectator_tiles[0].space == 9
 
 
 def test_remaining_dice_use_canonical_order() -> None:

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -6,7 +6,9 @@ from camel_up.engine import (
     CAMEL_ORDER,
     DIE_ORDER,
     BoardState,
+    CamelId,
     CamelPosition,
+    DieId,
     GameState,
     SpectatorTile,
     carried_camels,
@@ -15,8 +17,13 @@ from camel_up.engine import (
 )
 
 
-def test_new_game_has_one_unplaced_position_per_camel() -> None:
-    state = GameState()
+def test_identifier_orders_are_derived_from_enum_declarations() -> None:
+    assert tuple(CamelId) == CAMEL_ORDER
+    assert tuple(DieId) == DIE_ORDER
+
+
+def test_pre_setup_game_has_one_unplaced_position_per_camel() -> None:
+    state = GameState.pre_setup()
 
     assert state.board.track_length == 17
     assert len(state.board.camel_positions) == len(CAMEL_ORDER)
@@ -34,16 +41,23 @@ def test_coordinates_are_the_only_source_for_derived_stack_order() -> None:
         CamelPosition(space=15, level=0),
         CamelPosition(space=16, level=0),
     )
-    state = GameState(board=BoardState(camel_positions=positions))
+    state = GameState(board=BoardState(track_length=17, camel_positions=positions))
 
-    assert stack_at(state, 4) == ("red", "green", "blue")
-    assert position_of(state, "green") == CamelPosition(space=4, level=1)
-    assert carried_camels(state, "green") == ("green", "blue")
+    assert stack_at(state, 4) == (
+        CamelId.RED,
+        CamelId.GREEN,
+        CamelId.BLUE,
+    )
+    assert position_of(state, CamelId.GREEN) == CamelPosition(space=4, level=1)
+    assert carried_camels(state, CamelId.GREEN) == (
+        CamelId.GREEN,
+        CamelId.BLUE,
+    )
 
 
 def test_unplaced_camel_cannot_carry_a_stack() -> None:
     with pytest.raises(ValueError, match="must be placed"):
-        carried_camels(GameState(), "red")
+        carried_camels(GameState.pre_setup(), CamelId.RED)
 
 
 @pytest.mark.parametrize(
@@ -67,7 +81,7 @@ def test_board_rejects_duplicate_or_non_contiguous_stack_levels(
     )
 
     with pytest.raises(ValueError, match="unique and contiguous"):
-        BoardState(camel_positions=padded_positions)
+        BoardState(track_length=17, camel_positions=padded_positions)
 
 
 def test_position_requires_both_coordinate_fields() -> None:
@@ -82,19 +96,53 @@ def test_spectator_tiles_have_canonical_player_order() -> None:
     )
 
     with pytest.raises(ValueError, match="ordered by player_id"):
-        BoardState(spectator_tiles=tiles)
+        BoardState(
+            track_length=17,
+            camel_positions=BoardState.empty().camel_positions,
+            spectator_tiles=tiles,
+        )
+
+
+def test_board_validates_populated_mid_game_tile_snapshots() -> None:
+    board = replace(
+        BoardState.empty(),
+        spectator_tiles=(
+            SpectatorTile(player_id=0, space=3, effect=-1),
+            SpectatorTile(player_id=1, space=5, effect=1),
+        ),
+    )
+
+    assert [tile.space for tile in board.spectator_tiles] == [3, 5]
+
+    with pytest.raises(ValueError, match="cannot share a space"):
+        replace(
+            board,
+            spectator_tiles=(
+                SpectatorTile(player_id=0, space=3, effect=-1),
+                SpectatorTile(player_id=1, space=3, effect=1),
+            ),
+        )
 
 
 def test_remaining_dice_use_canonical_order() -> None:
     with pytest.raises(ValueError, match="canonical order"):
-        GameState(remaining_dice=("blue", "red"))
+        GameState(
+            board=BoardState.empty(),
+            remaining_dice=(DieId.BLUE, DieId.RED),
+        )
 
 
 def test_game_states_are_hashable_and_replaceable_without_mutation() -> None:
-    state = GameState()
+    state = GameState.pre_setup()
     next_state = replace(
         state,
-        remaining_dice=("blue", "green", "yellow", "purple", "grey"),
+        remaining_dice=(
+            DieId.BLUE,
+            DieId.GREEN,
+            DieId.YELLOW,
+            DieId.PURPLE,
+            DieId.GREY,
+        ),
     )
 
     transpositions = {state: "root", next_state: "child"}

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -105,7 +105,7 @@ def test_board_rejects_duplicate_or_non_contiguous_stack_levels(
         BoardState(track_length=17, camel_positions=tuple(all_positions))
 
 
-def test_board_rejects_partial_camel_setup() -> None:
+def test_board_rejects_partial_camel_setup_snapshot() -> None:
     positions = list(BoardState.empty().camel_positions)
     positions[0] = CamelPosition(space=2, level=0)
 

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -1,22 +1,112 @@
-from camel_up.engine import Board, Camel, GameState
+from dataclasses import replace
+
+import pytest
+
+from camel_up.engine import (
+    CAMEL_ORDER,
+    DIE_ORDER,
+    BoardState,
+    CamelPosition,
+    GameState,
+    SpectatorTile,
+    carried_camels,
+    position_of,
+    stack_at,
+)
 
 
-def test_board_initializes_with_expected_spaces_and_dice() -> None:
-    board = Board(land_len=17)
+def test_new_game_has_one_unplaced_position_per_camel() -> None:
+    state = GameState()
 
-    assert len(board.blocks) == 17
-    assert board.dices == ["red", "blue", "green", "yellow", "purple", "grey"]
-
-
-def test_camel_can_be_constructed_with_position() -> None:
-    camel = Camel(color="red", block_id=0, stack_id=0)
-
-    assert camel.color == "red"
-    assert camel.block_id == 0
-    assert camel.stack_id == 0
+    assert state.board.track_length == 17
+    assert len(state.board.camel_positions) == len(CAMEL_ORDER)
+    assert all(not position.is_placed for position in state.board.camel_positions)
+    assert state.remaining_dice == DIE_ORDER
 
 
-def test_forward_placement_preserves_bottom_to_top_order() -> None:
+def test_coordinates_are_the_only_source_for_derived_stack_order() -> None:
+    positions = (
+        CamelPosition(space=4, level=0),
+        CamelPosition(space=4, level=2),
+        CamelPosition(space=4, level=1),
+        CamelPosition(space=7, level=0),
+        CamelPosition(),
+        CamelPosition(space=15, level=0),
+        CamelPosition(space=16, level=0),
+    )
+    state = GameState(board=BoardState(camel_positions=positions))
+
+    assert stack_at(state, 4) == ("red", "green", "blue")
+    assert position_of(state, "green") == CamelPosition(space=4, level=1)
+    assert carried_camels(state, "green") == ("green", "blue")
+
+
+def test_unplaced_camel_cannot_carry_a_stack() -> None:
+    with pytest.raises(ValueError, match="must be placed"):
+        carried_camels(GameState(), "red")
+
+
+@pytest.mark.parametrize(
+    "positions",
+    [
+        (
+            CamelPosition(space=4, level=0),
+            CamelPosition(space=4, level=0),
+        ),
+        (
+            CamelPosition(space=4, level=0),
+            CamelPosition(space=4, level=2),
+        ),
+    ],
+)
+def test_board_rejects_duplicate_or_non_contiguous_stack_levels(
+    positions: tuple[CamelPosition, CamelPosition],
+) -> None:
+    padded_positions = positions + tuple(
+        CamelPosition() for _ in range(len(CAMEL_ORDER) - len(positions))
+    )
+
+    with pytest.raises(ValueError, match="unique and contiguous"):
+        BoardState(camel_positions=padded_positions)
+
+
+def test_position_requires_both_coordinate_fields() -> None:
+    with pytest.raises(ValueError, match="both be set"):
+        CamelPosition(space=3)
+
+
+def test_spectator_tiles_have_canonical_player_order() -> None:
+    tiles = (
+        SpectatorTile(player_id=1, space=5, effect=1),
+        SpectatorTile(player_id=0, space=3, effect=-1),
+    )
+
+    with pytest.raises(ValueError, match="ordered by player_id"):
+        BoardState(spectator_tiles=tiles)
+
+
+def test_remaining_dice_use_canonical_order() -> None:
+    with pytest.raises(ValueError, match="canonical order"):
+        GameState(remaining_dice=("blue", "red"))
+
+
+def test_game_states_are_hashable_and_replaceable_without_mutation() -> None:
+    state = GameState()
+    next_state = replace(
+        state,
+        remaining_dice=("blue", "green", "yellow", "purple", "grey"),
+    )
+
+    transpositions = {state: "root", next_state: "child"}
+
+    assert state.remaining_dice == DIE_ORDER
+    assert transpositions[state] == "root"
+    assert transpositions[next_state] == "child"
+
+
+def test_legacy_components_preserve_prototype_stack_behavior() -> None:
+    from components import Board, Camel
+
     board = Board(land_len=17)
     red = Camel("red")
     blue = Camel("blue")
@@ -31,67 +121,3 @@ def test_forward_placement_preserves_bottom_to_top_order() -> None:
         (2, 1),
         (2, 2),
     ]
-
-
-def test_backward_placement_puts_moving_stack_under_existing_camels() -> None:
-    board = Board(land_len=17)
-    red = Camel("red")
-    blue = Camel("blue")
-    green = Camel("green")
-
-    board.place_camel(2, [green])
-    board.place_camel(2, [red, blue], forward=False)
-
-    assert board.blocks[2] == [red, blue, green]
-    assert [(camel.block_id, camel.stack_id) for camel in board.blocks[2]] == [
-        (2, 0),
-        (2, 1),
-        (2, 2),
-    ]
-
-
-def test_select_camel_returns_it_and_every_camel_above() -> None:
-    board = Board(land_len=17)
-    red = Camel("red")
-    blue = Camel("blue")
-    green = Camel("green")
-    board.place_camel(2, [red, blue, green])
-
-    moving_stack = board.select_camel(blue)
-
-    assert moving_stack == [blue, green]
-    assert board.blocks[2] == [red]
-
-
-def test_game_state_owns_camels_and_current_dice_inventory() -> None:
-    board = Board(land_len=17)
-    red = Camel("red")
-    state = GameState(board=board, camels={"red": red})
-
-    assert state.board is board
-    assert state.camels == {"red": red}
-    assert state.dice_inventory is board.dices
-
-    board.toss_dice()
-
-    assert len(state.dice_inventory) == 5
-
-    board.one_leg_reset()
-
-    assert state.dice_inventory is board.dices
-    assert state.dice_inventory == [
-        "red",
-        "blue",
-        "green",
-        "yellow",
-        "purple",
-        "grey",
-    ]
-
-
-def test_legacy_components_module_re_exports_engine_types() -> None:
-    from components import Board as LegacyBoard
-    from components import Camel as LegacyCamel
-
-    assert LegacyBoard is Board
-    assert LegacyCamel is Camel

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -41,15 +41,15 @@ def test_coordinates_are_the_only_source_for_derived_stack_order() -> None:
         CamelPosition(space=15, level=0),
         CamelPosition(space=16, level=0),
     )
-    state = GameState(board=BoardState(track_length=17, camel_positions=positions))
+    board = BoardState(track_length=17, camel_positions=positions)
 
-    assert stack_at(state, 4) == (
+    assert stack_at(board, 4) == (
         CamelId.RED,
         CamelId.GREEN,
         CamelId.BLUE,
     )
-    assert position_of(state, CamelId.GREEN) == CamelPosition(space=4, level=1)
-    assert carried_camels(state, CamelId.GREEN) == (
+    assert position_of(board, CamelId.GREEN) == CamelPosition(space=4, level=1)
+    assert carried_camels(board, CamelId.GREEN) == (
         CamelId.GREEN,
         CamelId.BLUE,
     )
@@ -57,7 +57,7 @@ def test_coordinates_are_the_only_source_for_derived_stack_order() -> None:
 
 def test_unplaced_camel_cannot_carry_a_stack() -> None:
     with pytest.raises(ValueError, match="must be placed"):
-        carried_camels(GameState.pre_setup(), CamelId.RED)
+        carried_camels(BoardState.empty(), CamelId.RED)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,20 +1,4 @@
 from camel_up.cli.main import main
-from components import Board, Camel
-
-
-def test_board_initializes_with_expected_spaces_and_dice() -> None:
-    board = Board(land_len=17)
-
-    assert len(board.blocks) == 17
-    assert board.dices == ["red", "blue", "green", "yellow", "purple", "grey"]
-
-
-def test_camel_can_be_constructed_with_position() -> None:
-    camel = Camel(color="red", block_id=0, stack_id=0)
-
-    assert camel.color == "red"
-    assert camel.block_id == 0
-    assert camel.stack_id == 0
 
 
 def test_cli_entry_point_is_importable() -> None:


### PR DESCRIPTION
## Summary

- add immutable, hashable `CamelPosition`, `BoardState`, and `GameState` types under `camel_up.engine`
- make camel coordinates the sole source of placement truth and derive bottom-to-top stacks through tested query helpers
- keep dice inventory canonical and explicit while leaving randomness and transitions outside state containers
- model spectator tiles as immutable state and validate core coordinate invariants
- isolate the mutable prototype `Board` and `Camel` behind a temporary CLI compatibility adapter
- align the Phase 1 plan with the canonical coordinate design

The immutable representation supports deterministic testing, RL observation encoding, safe MCTS branching, and transposition-table keys without storing a large observation tensor in each state.

## Verification

- `uv run python -m pytest` — 11 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python -m mypy`
- built and inspected the wheel
- ran `uv run camel-up` through a complete game
- measured derived stack lookup at about 1.8 microseconds and immutable state replacement at about 5.7 microseconds on the development machine