### PR TITLE
refactor: add deterministic dice and atomic setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,24 @@ Engine rules are deterministic, testable, and independent from CLI, agent, or
 training code. Initial camel placement is modeled as one atomic transition from
 an all-unplaced pre-setup state to a complete board; setup rolls do not create
 player decision states for agents or search.
+
+## Deterministic Engine Setup
+
+Pass an explicit random source to reproduce setup and dice results. Engine
+transitions return replacement states rather than mutating their inputs:
+
+```python
+import random
+
+from camel_up.engine import GameState, roll_die, setup_game
+
+rng = random.Random(123)
+pre_setup = GameState.pre_setup()
+state, setup_rolls = setup_game(pre_setup, rng)
+state, roll = roll_die(state, rng)
+```
+
+`setup_game` constructs all seven camel positions atomically. Its ordered
+`setup_rolls` can be used for replay or presentation without exposing partially
+populated engine states. Camel movement from `roll` is implemented by the next
+engine milestone.

--- a/docs/software-foundation-plan.md
+++ b/docs/software-foundation-plan.md
@@ -229,7 +229,7 @@ Review focus:
 
 #### PR 2: `refactor: add deterministic dice and atomic setup`
 
-Status: `Doing`
+Status: `Done`
 
 Suggested branch: `chore/deterministic-dice-setup`
 
@@ -255,11 +255,12 @@ Tasks:
 
 Acceptance criteria:
 
-- The same seed and dice state produce the same sequence of rolls.
-- Initial setup returns either the unchanged pre-setup state on failure or one
-  state containing all seven placed camels; it never exposes partial setup.
-- Dice removal and leg reset preserve canonical dice ordering.
-- All documented checks pass.
+- [x] The same seed and dice state produce the same sequence of rolls.
+- [x] Initial setup returns either the unchanged pre-setup state on failure or
+      one state containing all seven placed camels; it never exposes partial
+      setup.
+- [x] Dice removal and leg reset preserve canonical dice ordering.
+- [x] All documented checks pass.
 
 Review focus:
 
@@ -272,6 +273,8 @@ Non-goals:
   scoring, legal actions, turns, CLI migration, agents, and RL environments.
 
 #### PR 3: `refactor: add immutable stack movement rules`
+
+Status: `Todo`
 
 Suggested branch: `chore/immutable-stack-movement`
 
@@ -476,7 +479,7 @@ Acceptance criteria:
 
 ## Phase 3: Deterministic Engine
 
-Status: `Todo`
+Status: `Doing`
 
 Goal: Replace global, interactive, random behavior with explicit deterministic
 game state and rule APIs.
@@ -485,9 +488,9 @@ Tasks:
 
 - [ ] Represent engine state with dataclasses such as `CamelPosition`,
       `BoardState`, `GameState`, `DieRoll`, `SpectatorTile`, and player state.
-- [ ] Inject or store `random.Random` instead of using global `random`.
-- [ ] Remove printing and user input from engine logic.
-- [ ] Make dice rolling deterministic under a fixed seed.
+- [x] Inject or store `random.Random` instead of using global `random`.
+- [x] Remove printing and user input from engine logic.
+- [x] Make dice rolling deterministic under a fixed seed.
 - [ ] Preserve camel stack ordering semantics.
 - [ ] Define clear rule functions for movement, tile effects, leg reset, and
       game end.
@@ -507,7 +510,7 @@ Acceptance criteria:
 
 ## Phase 4: Rule Test Coverage
 
-Status: `Todo`
+Status: `Doing`
 
 Goal: Build confidence around high-risk game rules with focused tests.
 
@@ -523,7 +526,7 @@ High-priority areas:
 - [ ] End-of-game detection.
 - [ ] Winner and runner-up ordering.
 - [ ] Legal actions and legal action masks.
-- [ ] Determinism with fixed seeds.
+- [x] Determinism with fixed seeds.
 
 Acceptance criteria:
 
@@ -590,7 +593,7 @@ Tasks:
 
 - [x] Add GitHub Actions for tests, Ruff, formatting, and MyPy.
 - [ ] Add or update `CONTRIBUTING.md`.
-- [ ] Keep README setup and command instructions current.
+- [x] Keep README setup and command instructions current.
 - [ ] Add architecture notes once the engine API stabilizes.
 - [ ] Ensure `.gitignore` excludes virtualenvs, caches, checkpoints, datasets,
       and generated outputs.
@@ -611,7 +614,8 @@ The recommended first milestone is intentionally small and starts with CI:
       isolating the temporary mutable CLI adapter.
 - [ ] Update imports and CLI.
 - [ ] Expand Ruff and MyPy to check `src`.
-- [ ] Add focused tests for stack movement and deterministic dice rolling.
+- [ ] Add focused tests for stack movement.
+- [x] Add focused tests for deterministic dice rolling and atomic setup.
 
 This milestone establishes the package foundation without attempting to
 redesign the full game in one pass. Complete the remaining work through the

--- a/docs/software-foundation-plan.md
+++ b/docs/software-foundation-plan.md
@@ -227,44 +227,91 @@ Review focus:
 - State ownership, dataclass invariants, type design, and compatibility with the
   prototype.
 
-#### PR 2: `refactor: extract deterministic dice and movement rules`
+#### PR 2: `refactor: add deterministic dice and atomic setup`
 
-Suggested branch: `chore/deterministic-dice-movement`
+Status: `Doing`
 
-Goal: Move the first high-risk rules behind deterministic, testable engine
-functions.
+Suggested branch: `chore/deterministic-dice-setup`
+
+Goal: Establish deterministic dice transitions and commit initial camel
+placement as one complete state change.
 
 Tasks:
 
-- [ ] Add `engine.dice` for dice inventory, die selection, grey die handling,
-      and leg dice reset.
-- [ ] Pass or store a seeded `random.Random` instance instead of using global
+- [x] Add `engine.dice` for dice inventory, die selection, grey die face
+      generation, and leg dice reset.
+- [x] Pass or store a seeded `random.Random` instance instead of using global
       random functions.
-- [ ] Add an atomic seeded setup transition that calculates all starting camel
+- [x] Add an immutable `DieRoll` result that records the selected die, camel,
+      and distance without storing the random generator in `GameState`.
+- [x] Emit unambiguous immutable setup rolls that distinguish the grey die's
+      printed camel from the crazy camel chosen for placement.
+- [x] Add an atomic seeded setup transition that calculates all starting camel
       positions before constructing the next `GameState`.
-- [ ] Add `engine.movement` for selecting a camel and every camel above it,
-      placing stacks, updating positions, forward movement, backward movement,
-      and finish-line handling.
-- [ ] Keep engine functions free of terminal input and output.
-- [ ] Add concrete movement tests for stack ordering and moving a camel with
-      camels above it.
-- [ ] Add deterministic dice tests that compare repeated rolls from the same
+- [x] Keep engine functions free of terminal input and output.
+- [x] Add deterministic dice tests that compare repeated rolls from the same
       seed, including grey die behavior.
-- [ ] Retain compatibility wrappers only where the CLI still needs them.
+- [x] Retain compatibility wrappers only where the CLI still needs them.
 
 Acceptance criteria:
 
 - The same seed and dice state produce the same sequence of rolls.
-- Moving a camel preserves the order of the carried stack.
-- Crazy camel backward movement has an explicit tested ordering rule.
+- Initial setup returns either the unchanged pre-setup state on failure or one
+  state containing all seven placed camels; it never exposes partial setup.
+- Dice removal and leg reset preserve canonical dice ordering.
 - All documented checks pass.
 
 Review focus:
 
-- Randomness injection, grey die behavior, backward movement, and camel stack
-  semantics.
+- Randomness injection, state ownership, grey die behavior, setup ordering, and
+  atomicity.
 
-#### PR 3: `feat: add player state foundation`
+Non-goals:
+
+- Camel movement after setup, spectator tile effects, player state, betting,
+  scoring, legal actions, turns, CLI migration, agents, and RL environments.
+
+#### PR 3: `refactor: add immutable stack movement rules`
+
+Suggested branch: `chore/immutable-stack-movement`
+
+Goal: Move camel movement behind deterministic, immutable engine functions
+using the stable state and dice results from PR 2.
+
+Tasks:
+
+- [ ] Add `engine.movement` for selecting a camel and every camel above it,
+      placing stacks, updating positions, racing-camel clockwise movement,
+      crazy-camel counterclockwise movement, and finish-line handling.
+- [ ] Resolve a grey die's printed camel to the moving crazy camel, including
+      the passenger and stacked-crazy-camel overrides.
+- [ ] Place normally moving camel units above the destination stack; defer the
+      under-stack rule for booing spectator tiles to the tile-rules PR.
+- [ ] Keep movement functions free of random selection, terminal input, and
+      terminal output.
+- [ ] Add concrete movement tests for stack ordering, moving a camel with
+      camels above it, crazy-camel counterclockwise movement, and finish-line
+      behavior.
+
+Acceptance criteria:
+
+- Moving a camel preserves the order of the carried stack.
+- Crazy camel counterclockwise movement and grey-die overrides are explicitly
+  tested.
+- Source and destination stack levels remain contiguous after every move.
+- All documented checks pass.
+
+Review focus:
+
+- Clockwise and counterclockwise placement, carried-stack semantics,
+  finish-line boundaries, and immutable board replacement.
+
+Non-goals:
+
+- Spectator tile effects, player state, betting, scoring, legal actions, turns,
+  CLI migration, agents, and RL environments.
+
+#### PR 4: `feat: add player state foundation`
 
 Suggested branch: `feat/player-state-foundation`
 
@@ -298,7 +345,7 @@ Review focus:
 - State ownership, canonical ordering, avoiding duplicated facts, and future
   observation encoding.
 
-#### PR 4: `feat: add betting and scoring rules`
+#### PR 5: `feat: add betting and scoring rules`
 
 Suggested branch: `feat/betting-scoring-rules`
 
@@ -332,7 +379,7 @@ Review focus:
 - Public versus player-owned state, payout correctness, ordered bets, and leg
   reset boundaries.
 
-#### PR 5: `feat: add legal actions and turn progression`
+#### PR 6: `feat: add legal actions and turn progression`
 
 Suggested branch: `feat/legal-actions-turns`
 
@@ -364,7 +411,7 @@ Review focus:
 - Legal-action completeness, stable action indices, turn boundaries, event
   design, and deterministic composition of rule modules.
 
-#### PR 6: `refactor: migrate CLI to engine API`
+#### PR 7: `refactor: migrate CLI to engine API`
 
 Suggested branch: `chore/engine-cli-cutover`
 
@@ -398,8 +445,8 @@ Review focus:
   imports.
 
 RL observation encoding, environment wrappers, agents, and training code remain
-outside this sequence. Add them only after PR 5 stabilizes the state, action,
-event, and legal-action-mask contracts. PR 6 is deliberately the first consumer
+outside this sequence. Add them only after PR 6 stabilizes the state, action,
+event, and legal-action-mask contracts. PR 7 is deliberately the first consumer
 migration so it does not need to be rewritten around incomplete engine APIs.
 
 ## Phase 2: Tooling Baseline

--- a/src/camel_up/engine/__init__.py
+++ b/src/camel_up/engine/__init__.py
@@ -1,5 +1,12 @@
 """Stable public types and queries for the Camel Up engine."""
 
+from camel_up.engine.dice import (
+    DieRoll,
+    SetupRoll,
+    reset_leg_dice,
+    roll_die,
+    setup_game,
+)
 from camel_up.engine.state import (
     CAMEL_ORDER,
     DIE_ORDER,
@@ -21,9 +28,14 @@ __all__ = [
     "CamelId",
     "CamelPosition",
     "DieId",
+    "DieRoll",
     "GameState",
     "SpectatorTile",
+    "SetupRoll",
     "carried_camels",
     "position_of",
+    "reset_leg_dice",
+    "roll_die",
+    "setup_game",
     "stack_at",
 ]

--- a/src/camel_up/engine/dice.py
+++ b/src/camel_up/engine/dice.py
@@ -132,7 +132,9 @@ def reset_leg_dice(state: GameState) -> GameState:
         raise ValueError("initial setup must be completed before resetting dice")
     if state.terminal:
         raise ValueError("cannot reset dice after the game has ended")
-    if len(state.remaining_dice) != 1:
+    if not state.remaining_dice:
+        raise ValueError("cannot reset dice from an empty inventory")
+    if len(state.remaining_dice) > 1:
         raise ValueError("dice can only be reset after five rolls")
     return replace(state, remaining_dice=DIE_ORDER)
 

--- a/src/camel_up/engine/dice.py
+++ b/src/camel_up/engine/dice.py
@@ -1,0 +1,192 @@
+"""Deterministic dice transitions and atomic initial camel setup."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass, replace
+from types import MappingProxyType
+from typing import Final
+
+from camel_up.engine.state import (
+    CAMEL_ORDER,
+    DIE_ORDER,
+    BoardState,
+    CamelId,
+    CamelPosition,
+    DieId,
+    GameState,
+)
+
+_RACING_DICE: Final = DIE_ORDER[:-1]
+_CRAZY_CAMELS: Final = (CamelId.WHITE, CamelId.BLACK)
+_CAMEL_BY_DIE: Final = MappingProxyType(
+    {
+        DieId.RED: CamelId.RED,
+        DieId.BLUE: CamelId.BLUE,
+        DieId.GREEN: CamelId.GREEN,
+        DieId.YELLOW: CamelId.YELLOW,
+        DieId.PURPLE: CamelId.PURPLE,
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class DieRoll:
+    """One physical die result before movement-specific resolution.
+
+    For the grey die, ``camel`` is the color printed on the rolled face.
+    Movement rules may later select the other crazy camel when stack rules
+    require it.
+    """
+
+    die: DieId
+    camel: CamelId
+    distance: int
+
+    def __post_init__(self) -> None:
+        """Require a valid camel face and a physical die distance."""
+        if self.distance not in (1, 2, 3):
+            raise ValueError("distance must be 1, 2, or 3")
+        if self.die is DieId.GREY:
+            if self.camel not in _CRAZY_CAMELS:
+                raise ValueError("grey die must show a crazy camel")
+        elif _CAMEL_BY_DIE.get(self.die) is not self.camel:
+            raise ValueError("racing die must match its camel")
+
+
+@dataclass(frozen=True, slots=True)
+class SetupRoll:
+    """A physical setup roll paired with the camel placed by that roll.
+
+    During setup, the color printed on the grey die does not decide which
+    crazy camel is placed. Keeping both facts makes setup events unambiguous.
+    """
+
+    roll: DieRoll
+    camel: CamelId
+
+    def __post_init__(self) -> None:
+        """Require the placement camel to match the kind of die rolled."""
+        if self.roll.die is DieId.GREY:
+            if self.camel not in _CRAZY_CAMELS:
+                raise ValueError("grey setup roll must place a crazy camel")
+        elif self.camel is not self.roll.camel:
+            raise ValueError("racing setup roll must place its matching camel")
+
+
+def roll_die(state: GameState, rng: random.Random) -> tuple[GameState, DieRoll]:
+    """Roll one available die and return a replacement game state.
+
+    A Camel Up leg ends after five of the six dice have been rolled, so the
+    final die remains unavailable until the caller performs a complete leg
+    transition and resets the dice inventory.
+    """
+    if not all(position.is_placed for position in state.board.camel_positions):
+        raise ValueError("initial setup must be completed before rolling")
+    if state.terminal:
+        raise ValueError("cannot roll dice after the game has ended")
+    if len(state.remaining_dice) <= 1:
+        raise ValueError("the leg is complete; reset dice before rolling again")
+
+    die = rng.choice(state.remaining_dice)
+    roll = _roll_physical_die(die, rng)
+    remaining_dice = tuple(
+        candidate for candidate in state.remaining_dice if candidate != die
+    )
+    return replace(state, remaining_dice=remaining_dice), roll
+
+
+def reset_leg_dice(state: GameState) -> GameState:
+    """Restore the canonical dice inventory after five rolls.
+
+    This transition intentionally resets only dice. Turn orchestration will
+    later compose it with scoring, tile returns, and leg-number advancement.
+    """
+    if not all(position.is_placed for position in state.board.camel_positions):
+        raise ValueError("initial setup must be completed before resetting dice")
+    if state.terminal:
+        raise ValueError("cannot reset dice after the game has ended")
+    if len(state.remaining_dice) != 1:
+        raise ValueError("dice can only be reset after five rolls")
+    return replace(state, remaining_dice=DIE_ORDER)
+
+
+def setup_game(
+    state: GameState,
+    rng: random.Random,
+) -> tuple[GameState, tuple[SetupRoll, ...]]:
+    """Place all seven camels in one immutable, seeded transition.
+
+    The five racing dice are rolled in a randomized order, which resolves the
+    rulebook's arbitrary ordering for camels that start on the same space. The
+    grey die is then rolled once for each crazy camel. No partially populated
+    ``BoardState`` is constructed or returned.
+    """
+    _validate_pre_setup_state(state)
+
+    racing_dice = list(_RACING_DICE)
+    rng.shuffle(racing_dice)
+    setup_rolls: list[SetupRoll] = []
+    for die in racing_dice:
+        roll = _roll_physical_die(die, rng)
+        setup_rolls.append(SetupRoll(roll=roll, camel=roll.camel))
+
+    unplaced_crazy_camels = list(_CRAZY_CAMELS)
+    for _ in _CRAZY_CAMELS:
+        roll = _roll_physical_die(DieId.GREY, rng)
+        camel = (
+            rng.choice(unplaced_crazy_camels)
+            if len(unplaced_crazy_camels) > 1
+            else unplaced_crazy_camels[0]
+        )
+        unplaced_crazy_camels.remove(camel)
+        setup_rolls.append(SetupRoll(roll=roll, camel=camel))
+
+    spaces_by_camel: dict[CamelId, int] = {}
+    stacks_by_space: dict[int, list[CamelId]] = {}
+    for setup_roll in setup_rolls:
+        if setup_roll.roll.die is DieId.GREY:
+            space = state.board.track_length - setup_roll.roll.distance - 1
+        else:
+            space = setup_roll.roll.distance - 1
+        spaces_by_camel[setup_roll.camel] = space
+        stacks_by_space.setdefault(space, []).append(setup_roll.camel)
+
+    levels_by_camel = {
+        camel: level
+        for stack in stacks_by_space.values()
+        for level, camel in enumerate(stack)
+    }
+    positions = tuple(
+        CamelPosition(
+            space=spaces_by_camel[camel],
+            level=levels_by_camel[camel],
+        )
+        for camel in CAMEL_ORDER
+    )
+    board = BoardState(
+        track_length=state.board.track_length,
+        camel_positions=positions,
+    )
+    return replace(state, board=board, remaining_dice=DIE_ORDER), tuple(setup_rolls)
+
+
+def _roll_physical_die(die: DieId, rng: random.Random) -> DieRoll:
+    """Return one result from a racing or grey die."""
+    distance = rng.randint(1, 3)
+    camel = rng.choice(_CRAZY_CAMELS) if die is DieId.GREY else _CAMEL_BY_DIE[die]
+    return DieRoll(die=die, camel=camel, distance=distance)
+
+
+def _validate_pre_setup_state(state: GameState) -> None:
+    """Reject invalid setup inputs before consuming any randomness."""
+    if any(position.is_placed for position in state.board.camel_positions):
+        raise ValueError("initial setup has already been completed")
+    if state.board.spectator_tiles:
+        raise ValueError("initial setup cannot contain spectator tiles")
+    if state.board.track_length < 7:
+        raise ValueError("track must contain at least seven spaces for setup")
+    if state.remaining_dice != DIE_ORDER:
+        raise ValueError("initial setup requires the complete dice inventory")
+    if state.leg_number != 1 or state.terminal:
+        raise ValueError("initial setup requires a new, non-terminal game")

--- a/src/camel_up/engine/dice.py
+++ b/src/camel_up/engine/dice.py
@@ -37,6 +37,12 @@ class DieRoll:
     For the grey die, ``camel`` is the color printed on the rolled face.
     Movement rules may later select the other crazy camel when stack rules
     require it.
+
+    Attributes:
+        die: The physical die selected from the current leg's inventory.
+        camel: The matching racing camel or the crazy camel color printed on
+            the grey die.
+        distance: The rolled distance, from one through three spaces.
     """
 
     die: DieId
@@ -60,6 +66,10 @@ class SetupRoll:
 
     During setup, the color printed on the grey die does not decide which
     crazy camel is placed. Keeping both facts makes setup events unambiguous.
+
+    Attributes:
+        roll: The physical die result used for initial placement.
+        camel: The camel placed by that result.
     """
 
     roll: DieRoll
@@ -75,11 +85,19 @@ class SetupRoll:
 
 
 def roll_die(state: GameState, rng: random.Random) -> tuple[GameState, DieRoll]:
-    """Roll one available die and return a replacement game state.
+    """Roll one available die and remove it from the leg inventory.
 
     A Camel Up leg ends after five of the six dice have been rolled, so the
     final die remains unavailable until the caller performs a complete leg
     transition and resets the dice inventory.
+
+    Args:
+        state: A non-terminal game with completed setup and at least two dice
+            remaining in the current leg.
+        rng: The random source to consume for die selection and face generation.
+
+    Returns:
+        A tuple containing the replacement game state and physical die result.
     """
     if not all(position.is_placed for position in state.board.camel_positions):
         raise ValueError("initial setup must be completed before rolling")
@@ -101,6 +119,12 @@ def reset_leg_dice(state: GameState) -> GameState:
 
     This transition intentionally resets only dice. Turn orchestration will
     later compose it with scoring, tile returns, and leg-number advancement.
+
+    Args:
+        state: A non-terminal, fully set up game with one unrolled die left.
+
+    Returns:
+        A replacement game state with the canonical six-die inventory.
     """
     if not all(position.is_placed for position in state.board.camel_positions):
         raise ValueError("initial setup must be completed before resetting dice")
@@ -121,9 +145,25 @@ def setup_game(
     rulebook's arbitrary ordering for camels that start on the same space. The
     grey die is then rolled once for each crazy camel. No partially populated
     ``BoardState`` is constructed or returned.
+
+    Args:
+        state: A new pre-setup game with an empty board and complete dice
+            inventory.
+        rng: The random source to consume for rolls, stack order, and crazy
+            camel placement order.
+
+    Returns:
+        A tuple containing the fully set up game state and its ordered setup
+        roll events.
     """
     _validate_pre_setup_state(state)
+    setup_rolls = _generate_setup_rolls(rng)
+    board = _build_setup_board(state.board.track_length, setup_rolls)
+    return replace(state, board=board, remaining_dice=DIE_ORDER), setup_rolls
 
+
+def _generate_setup_rolls(rng: random.Random) -> tuple[SetupRoll, ...]:
+    """Generate ordered racing and crazy camel placement rolls."""
     racing_dice = list(_RACING_DICE)
     rng.shuffle(racing_dice)
     setup_rolls: list[SetupRoll] = []
@@ -141,12 +181,19 @@ def setup_game(
         )
         unplaced_crazy_camels.remove(camel)
         setup_rolls.append(SetupRoll(roll=roll, camel=camel))
+    return tuple(setup_rolls)
 
+
+def _build_setup_board(
+    track_length: int,
+    setup_rolls: tuple[SetupRoll, ...],
+) -> BoardState:
+    """Build one complete board from validated setup roll events."""
     spaces_by_camel: dict[CamelId, int] = {}
     stacks_by_space: dict[int, list[CamelId]] = {}
     for setup_roll in setup_rolls:
         if setup_roll.roll.die is DieId.GREY:
-            space = state.board.track_length - setup_roll.roll.distance - 1
+            space = track_length - setup_roll.roll.distance - 1
         else:
             space = setup_roll.roll.distance - 1
         spaces_by_camel[setup_roll.camel] = space
@@ -164,11 +211,10 @@ def setup_game(
         )
         for camel in CAMEL_ORDER
     )
-    board = BoardState(
-        track_length=state.board.track_length,
+    return BoardState(
+        track_length=track_length,
         camel_positions=positions,
     )
-    return replace(state, board=board, remaining_dice=DIE_ORDER), tuple(setup_rolls)
 
 
 def _roll_physical_die(die: DieId, rng: random.Random) -> DieRoll:

--- a/src/camel_up/engine/dice.py
+++ b/src/camel_up/engine/dice.py
@@ -65,22 +65,24 @@ class SetupRoll:
     """A physical setup roll paired with the camel placed by that roll.
 
     During setup, the color printed on the grey die does not decide which
-    crazy camel is placed. Keeping both facts makes setup events unambiguous.
+    crazy camel is placed. For racing dice, ``placed_camel`` matches the
+    camel on ``roll``; for the grey die, it records the separately chosen
+    crazy camel. Keeping both facts makes setup events replayable.
 
     Attributes:
         roll: The physical die result used for initial placement.
-        camel: The camel placed by that result.
+        placed_camel: The camel placed by that result.
     """
 
     roll: DieRoll
-    camel: CamelId
+    placed_camel: CamelId
 
     def __post_init__(self) -> None:
         """Require the placement camel to match the kind of die rolled."""
         if self.roll.die is DieId.GREY:
-            if self.camel not in _CRAZY_CAMELS:
+            if self.placed_camel not in _CRAZY_CAMELS:
                 raise ValueError("grey setup roll must place a crazy camel")
-        elif self.camel is not self.roll.camel:
+        elif self.placed_camel is not self.roll.camel:
             raise ValueError("racing setup roll must place its matching camel")
 
 
@@ -154,7 +156,8 @@ def setup_game(
 
     Returns:
         A tuple containing the fully set up game state and its ordered setup
-        roll events.
+        roll events. The events allow a caller to replay setup without exposing
+        partially populated engine states.
     """
     _validate_pre_setup_state(state)
     setup_rolls = _generate_setup_rolls(rng)
@@ -169,7 +172,7 @@ def _generate_setup_rolls(rng: random.Random) -> tuple[SetupRoll, ...]:
     setup_rolls: list[SetupRoll] = []
     for die in racing_dice:
         roll = _roll_physical_die(die, rng)
-        setup_rolls.append(SetupRoll(roll=roll, camel=roll.camel))
+        setup_rolls.append(SetupRoll(roll=roll, placed_camel=roll.camel))
 
     unplaced_crazy_camels = list(_CRAZY_CAMELS)
     for _ in _CRAZY_CAMELS:
@@ -180,7 +183,7 @@ def _generate_setup_rolls(rng: random.Random) -> tuple[SetupRoll, ...]:
             else unplaced_crazy_camels[0]
         )
         unplaced_crazy_camels.remove(camel)
-        setup_rolls.append(SetupRoll(roll=roll, camel=camel))
+        setup_rolls.append(SetupRoll(roll=roll, placed_camel=camel))
     return tuple(setup_rolls)
 
 
@@ -196,8 +199,8 @@ def _build_setup_board(
             space = track_length - setup_roll.roll.distance - 1
         else:
             space = setup_roll.roll.distance - 1
-        spaces_by_camel[setup_roll.camel] = space
-        stacks_by_space.setdefault(space, []).append(setup_roll.camel)
+        spaces_by_camel[setup_roll.placed_camel] = space
+        stacks_by_space.setdefault(space, []).append(setup_roll.placed_camel)
 
     levels_by_camel = {
         camel: level
@@ -218,7 +221,11 @@ def _build_setup_board(
 
 
 def _roll_physical_die(die: DieId, rng: random.Random) -> DieRoll:
-    """Return one result from a racing or grey die."""
+    """Return one unresolved result from a racing or grey die.
+
+    For the grey die, this records the printed camel color. Stack-dependent
+    overrides that determine the moving crazy camel belong to movement rules.
+    """
     distance = rng.randint(1, 3)
     camel = rng.choice(_CRAZY_CAMELS) if die is DieId.GREY else _CAMEL_BY_DIE[die]
     return DieRoll(die=die, camel=camel, distance=distance)

--- a/tests/engine/test_dice.py
+++ b/tests/engine/test_dice.py
@@ -38,16 +38,16 @@ def test_die_roll_rejects_mismatched_camel_or_distance() -> None:
 def test_setup_roll_distinguishes_grey_face_from_placed_camel() -> None:
     setup_roll = SetupRoll(
         roll=DieRoll(die=DieId.GREY, camel=CamelId.BLACK, distance=2),
-        camel=CamelId.WHITE,
+        placed_camel=CamelId.WHITE,
     )
 
     assert setup_roll.roll.camel is CamelId.BLACK
-    assert setup_roll.camel is CamelId.WHITE
+    assert setup_roll.placed_camel is CamelId.WHITE
 
     with pytest.raises(ValueError, match="matching camel"):
         SetupRoll(
             roll=DieRoll(die=DieId.RED, camel=CamelId.RED, distance=1),
-            camel=CamelId.BLUE,
+            placed_camel=CamelId.BLUE,
         )
 
 
@@ -107,8 +107,8 @@ def test_leg_ends_with_one_unrolled_die_and_can_then_reset() -> None:
 
     reset_state = reset_leg_dice(state)
 
+    assert len(state.remaining_dice) == 1
     assert reset_state.remaining_dice == DIE_ORDER
-    assert state.remaining_dice != DIE_ORDER
 
 
 def test_dice_cannot_reset_before_five_rolls() -> None:
@@ -121,6 +121,10 @@ def test_dice_cannot_reset_before_five_rolls() -> None:
     )
     with pytest.raises(ValueError, match="setup must be completed"):
         reset_leg_dice(pre_setup)
+
+    no_dice_state = replace(_setup_state(), remaining_dice=())
+    with pytest.raises(ValueError, match="after five rolls"):
+        reset_leg_dice(no_dice_state)
 
 
 def test_setup_is_atomic_complete_and_seeded() -> None:
@@ -142,7 +146,7 @@ def test_setup_is_atomic_complete_and_seeded() -> None:
         DieId.GREY,
         DieId.GREY,
     ]
-    assert {setup_roll.camel for setup_roll in first_rolls[5:]} == {
+    assert {setup_roll.placed_camel for setup_roll in first_rolls[5:]} == {
         CamelId.WHITE,
         CamelId.BLACK,
     }
@@ -158,14 +162,15 @@ def test_setup_rolls_define_positions_and_stack_order() -> None:
             if setup_roll.roll.die is DieId.GREY
             else setup_roll.roll.distance - 1
         )
-        expected_stacks.setdefault(space, []).append(setup_roll.camel)
-        assert position_of(state.board, setup_roll.camel).space == space
+        expected_stacks.setdefault(space, []).append(setup_roll.placed_camel)
+        assert position_of(state.board, setup_roll.placed_camel).space == space
 
     for space, expected_stack in expected_stacks.items():
         assert stack_at(state.board, space) == tuple(expected_stack)
 
     assert rolls[5].roll.distance == rolls[6].roll.distance
-    assert position_of(state.board, rolls[6].camel).level == 1
+    assert position_of(state.board, rolls[5].placed_camel).level == 0
+    assert position_of(state.board, rolls[6].placed_camel).level == 1
 
 
 def test_setup_rejection_does_not_change_state_or_rng() -> None:
@@ -199,17 +204,24 @@ def test_roll_requires_setup_and_non_terminal_game() -> None:
         roll_die(terminal_state, random.Random(2))
 
 
-def test_setup_places_every_camel_once_in_canonical_positions_tuple() -> None:
-    state, _ = setup_game(GameState.pre_setup(), random.Random(12))
-
-    positions = {
-        camel: position
-        for camel, position in zip(
-            CAMEL_ORDER,
-            state.board.camel_positions,
-            strict=True,
+def test_setup_position_tuple_matches_canonical_camel_order() -> None:
+    state, setup_rolls = setup_game(GameState.pre_setup(), random.Random(12))
+    expected_positions_by_camel: dict[CamelId, CamelPosition] = {}
+    expected_levels_by_space: dict[int, int] = {}
+    for setup_roll in setup_rolls:
+        space = (
+            state.board.track_length - setup_roll.roll.distance - 1
+            if setup_roll.roll.die is DieId.GREY
+            else setup_roll.roll.distance - 1
         )
-    }
+        level = expected_levels_by_space.get(space, 0)
+        expected_positions_by_camel[setup_roll.placed_camel] = CamelPosition(
+            space=space,
+            level=level,
+        )
+        expected_levels_by_space[space] = level + 1
 
-    assert set(positions) == set(CAMEL_ORDER)
-    assert all(isinstance(position, CamelPosition) for position in positions.values())
+    assert len(expected_positions_by_camel) == len(CAMEL_ORDER)
+    assert tuple(expected_positions_by_camel[camel] for camel in CAMEL_ORDER) == (
+        state.board.camel_positions
+    )

--- a/tests/engine/test_dice.py
+++ b/tests/engine/test_dice.py
@@ -123,7 +123,7 @@ def test_dice_cannot_reset_before_five_rolls() -> None:
         reset_leg_dice(pre_setup)
 
     no_dice_state = replace(_setup_state(), remaining_dice=())
-    with pytest.raises(ValueError, match="after five rolls"):
+    with pytest.raises(ValueError, match="empty inventory"):
         reset_leg_dice(no_dice_state)
 
 
@@ -152,7 +152,7 @@ def test_setup_is_atomic_complete_and_seeded() -> None:
     }
 
 
-def test_setup_rolls_define_positions_and_stack_order() -> None:
+def test_initial_setup_rolls_define_positions_and_stack_order() -> None:
     state, rolls = setup_game(GameState.pre_setup(), random.Random(0))
 
     expected_stacks: dict[int, list[CamelId]] = {}
@@ -168,9 +168,10 @@ def test_setup_rolls_define_positions_and_stack_order() -> None:
     for space, expected_stack in expected_stacks.items():
         assert stack_at(state.board, space) == tuple(expected_stack)
 
-    assert rolls[5].roll.distance == rolls[6].roll.distance
-    assert position_of(state.board, rolls[5].placed_camel).level == 0
-    assert position_of(state.board, rolls[6].placed_camel).level == 1
+    first_crazy_setup, second_crazy_setup = rolls[5:]
+    assert first_crazy_setup.roll.distance == second_crazy_setup.roll.distance
+    assert position_of(state.board, first_crazy_setup.placed_camel).level == 0
+    assert position_of(state.board, second_crazy_setup.placed_camel).level == 1
 
 
 def test_setup_rejection_does_not_change_state_or_rng() -> None:
@@ -221,7 +222,9 @@ def test_setup_position_tuple_matches_canonical_camel_order() -> None:
         )
         expected_levels_by_space[space] = level + 1
 
-    assert len(expected_positions_by_camel) == len(CAMEL_ORDER)
-    assert tuple(expected_positions_by_camel[camel] for camel in CAMEL_ORDER) == (
-        state.board.camel_positions
+    expected_canonical_positions = tuple(
+        expected_positions_by_camel[camel] for camel in CAMEL_ORDER
     )
+
+    assert len(expected_positions_by_camel) == len(CAMEL_ORDER)
+    assert state.board.camel_positions == expected_canonical_positions

--- a/tests/engine/test_dice.py
+++ b/tests/engine/test_dice.py
@@ -1,0 +1,215 @@
+import random
+from dataclasses import replace
+
+import pytest
+
+from camel_up.engine import (
+    CAMEL_ORDER,
+    DIE_ORDER,
+    BoardState,
+    CamelId,
+    CamelPosition,
+    DieId,
+    DieRoll,
+    GameState,
+    SetupRoll,
+    position_of,
+    reset_leg_dice,
+    roll_die,
+    setup_game,
+    stack_at,
+)
+
+
+def _setup_state(seed: int = 1) -> GameState:
+    state, _ = setup_game(GameState.pre_setup(), random.Random(seed))
+    return state
+
+
+def test_die_roll_rejects_mismatched_camel_or_distance() -> None:
+    with pytest.raises(ValueError, match="must match"):
+        DieRoll(die=DieId.RED, camel=CamelId.BLUE, distance=1)
+    with pytest.raises(ValueError, match="crazy camel"):
+        DieRoll(die=DieId.GREY, camel=CamelId.RED, distance=1)
+    with pytest.raises(ValueError, match="1, 2, or 3"):
+        DieRoll(die=DieId.BLUE, camel=CamelId.BLUE, distance=4)
+
+
+def test_setup_roll_distinguishes_grey_face_from_placed_camel() -> None:
+    setup_roll = SetupRoll(
+        roll=DieRoll(die=DieId.GREY, camel=CamelId.BLACK, distance=2),
+        camel=CamelId.WHITE,
+    )
+
+    assert setup_roll.roll.camel is CamelId.BLACK
+    assert setup_roll.camel is CamelId.WHITE
+
+    with pytest.raises(ValueError, match="matching camel"):
+        SetupRoll(
+            roll=DieRoll(die=DieId.RED, camel=CamelId.RED, distance=1),
+            camel=CamelId.BLUE,
+        )
+
+
+def test_same_seed_and_state_produce_the_same_roll_sequence() -> None:
+    first_state = _setup_state()
+    second_state = first_state
+    first_rng = random.Random(2026)
+    second_rng = random.Random(2026)
+    first_rolls: list[DieRoll] = []
+    second_rolls: list[DieRoll] = []
+
+    for _ in range(5):
+        first_state, first_roll = roll_die(first_state, first_rng)
+        second_state, second_roll = roll_die(second_state, second_rng)
+        first_rolls.append(first_roll)
+        second_rolls.append(second_roll)
+
+    assert first_rolls == second_rolls
+    assert first_state == second_state
+    assert len({roll.die for roll in first_rolls}) == 5
+    assert len(first_state.remaining_dice) == 1
+
+
+def test_roll_removes_only_the_selected_die() -> None:
+    state = _setup_state()
+
+    next_state, roll = roll_die(state, random.Random(7))
+
+    assert roll.die not in next_state.remaining_dice
+    assert next_state.remaining_dice == tuple(
+        die for die in DIE_ORDER if die is not roll.die
+    )
+    assert state.remaining_dice == DIE_ORDER
+
+
+def test_grey_die_generates_a_seeded_crazy_camel_face() -> None:
+    state = replace(
+        _setup_state(),
+        remaining_dice=(DieId.PURPLE, DieId.GREY),
+    )
+
+    next_state, roll = roll_die(state, random.Random(0))
+
+    assert roll == DieRoll(die=DieId.GREY, camel=CamelId.WHITE, distance=2)
+    assert next_state.remaining_dice == (DieId.PURPLE,)
+
+
+def test_leg_ends_with_one_unrolled_die_and_can_then_reset() -> None:
+    state = _setup_state()
+    rng = random.Random(9)
+
+    for _ in range(5):
+        state, _ = roll_die(state, rng)
+
+    with pytest.raises(ValueError, match="leg is complete"):
+        roll_die(state, rng)
+
+    reset_state = reset_leg_dice(state)
+
+    assert reset_state.remaining_dice == DIE_ORDER
+    assert state.remaining_dice != DIE_ORDER
+
+
+def test_dice_cannot_reset_before_five_rolls() -> None:
+    with pytest.raises(ValueError, match="after five rolls"):
+        reset_leg_dice(_setup_state())
+
+    pre_setup = replace(
+        GameState.pre_setup(),
+        remaining_dice=(DieId.GREY,),
+    )
+    with pytest.raises(ValueError, match="setup must be completed"):
+        reset_leg_dice(pre_setup)
+
+
+def test_setup_is_atomic_complete_and_seeded() -> None:
+    pre_setup = GameState.pre_setup()
+
+    first_state, first_rolls = setup_game(pre_setup, random.Random(31))
+    second_state, second_rolls = setup_game(pre_setup, random.Random(31))
+
+    assert first_state == second_state
+    assert first_rolls == second_rolls
+    assert pre_setup.board == BoardState.empty()
+    assert all(position.is_placed for position in first_state.board.camel_positions)
+    assert first_state.remaining_dice == DIE_ORDER
+    assert len(first_rolls) == 7
+    assert {setup_roll.roll.die for setup_roll in first_rolls[:5]} == set(
+        DIE_ORDER[:-1]
+    )
+    assert [setup_roll.roll.die for setup_roll in first_rolls[5:]] == [
+        DieId.GREY,
+        DieId.GREY,
+    ]
+    assert {setup_roll.camel for setup_roll in first_rolls[5:]} == {
+        CamelId.WHITE,
+        CamelId.BLACK,
+    }
+
+
+def test_setup_rolls_define_positions_and_stack_order() -> None:
+    state, rolls = setup_game(GameState.pre_setup(), random.Random(0))
+
+    expected_stacks: dict[int, list[CamelId]] = {}
+    for setup_roll in rolls:
+        space = (
+            state.board.track_length - setup_roll.roll.distance - 1
+            if setup_roll.roll.die is DieId.GREY
+            else setup_roll.roll.distance - 1
+        )
+        expected_stacks.setdefault(space, []).append(setup_roll.camel)
+        assert position_of(state.board, setup_roll.camel).space == space
+
+    for space, expected_stack in expected_stacks.items():
+        assert stack_at(state.board, space) == tuple(expected_stack)
+
+    assert rolls[5].roll.distance == rolls[6].roll.distance
+    assert position_of(state.board, rolls[6].camel).level == 1
+
+
+def test_setup_rejection_does_not_change_state_or_rng() -> None:
+    placed_state = _setup_state()
+    rng = random.Random(15)
+    rng_state = rng.getstate()
+
+    with pytest.raises(ValueError, match="already been completed"):
+        setup_game(placed_state, rng)
+
+    assert placed_state == _setup_state()
+    assert rng.getstate() == rng_state
+
+
+def test_setup_requires_complete_dice_inventory() -> None:
+    pre_setup = replace(
+        GameState.pre_setup(),
+        remaining_dice=(DieId.BLUE, DieId.GREEN),
+    )
+
+    with pytest.raises(ValueError, match="complete dice inventory"):
+        setup_game(pre_setup, random.Random(8))
+
+
+def test_roll_requires_setup_and_non_terminal_game() -> None:
+    with pytest.raises(ValueError, match="setup must be completed"):
+        roll_die(GameState.pre_setup(), random.Random(2))
+
+    terminal_state = replace(_setup_state(), terminal=True)
+    with pytest.raises(ValueError, match="game has ended"):
+        roll_die(terminal_state, random.Random(2))
+
+
+def test_setup_places_every_camel_once_in_canonical_positions_tuple() -> None:
+    state, _ = setup_game(GameState.pre_setup(), random.Random(12))
+
+    positions = {
+        camel: position
+        for camel, position in zip(
+            CAMEL_ORDER,
+            state.board.camel_positions,
+            strict=True,
+        )
+    }
+
+    assert set(positions) == set(CAMEL_ORDER)
+    assert all(isinstance(position, CamelPosition) for position in positions.values())


### PR DESCRIPTION
## Outcome

Add deterministic dice transitions and commit initial camel placement as one complete immutable state change.

## Changes

- add immutable DieRoll and SetupRoll results
- inject random.Random for reproducible die selection and values
- remove rolled dice canonically and reset the inventory after five rolls
- place all five racing and two crazy camels atomically from a seed
- distinguish the grey die face from the crazy camel chosen during setup
- split the roadmap so immutable movement follows in a separate PR

## Non-goals

Camel movement, spectator tile effects, player state, betting, scoring, legal actions, turns, CLI migration, agents, and RL environments.

## Verification

- uv run python -m pytest — 32 passed
- uv run ruff check .
- uv run ruff format --check .
- uv run python -m mypy
- expanded Ruff and mypy checks over src/camel_up and tests