### PR TITLE
refactor: add immutable stack movement rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,15 +66,17 @@ transitions return replacement states rather than mutating their inputs:
 ```python
 import random
 
-from camel_up.engine import GameState, roll_die, setup_game
+from camel_up.engine import GameState, move_camel, roll_die, setup_game
 
 rng = random.Random(123)
 pre_setup = GameState.pre_setup()
 state, setup_rolls = setup_game(pre_setup, rng)
 state, roll = roll_die(state, rng)
+state = move_camel(state, roll)
 ```
 
 `setup_game` constructs all seven camel positions atomically. Its ordered
 `setup_rolls` can be used for replay or presentation without exposing partially
-populated engine states. Camel movement from `roll` is implemented by the next
-engine milestone.
+populated engine states. `move_camel` then applies the physical die result as a
+separate immutable transition, preserving carried-stack order and resolving
+the grey die's crazy-camel exceptions.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ training code. Initial camel placement is modeled as one atomic transition from
 an all-unplaced pre-setup state to a complete board; setup rolls do not create
 player decision states for agents or search.
 
-## Deterministic Engine Setup
+## Deterministic Engine Transitions
 
 Pass an explicit random source to reproduce setup and dice results. Engine
 transitions return replacement states rather than mutating their inputs:
@@ -79,4 +79,7 @@ state = move_camel(state, roll)
 `setup_rolls` can be used for replay or presentation without exposing partially
 populated engine states. `move_camel` then applies the physical die result as a
 separate immutable transition, preserving carried-stack order and resolving
-the grey die's crazy-camel exceptions.
+the grey die's crazy-camel exceptions. Crossing either finish boundary places
+the moved unit in the corresponding finish zone and returns a terminal state.
+Spectator-tile movement effects are deferred to a later engine milestone;
+`move_camel` currently rejects a move that would require one.

--- a/docs/software-foundation-plan.md
+++ b/docs/software-foundation-plan.md
@@ -284,8 +284,8 @@ using the stable state and dice results from PR 2.
 Tasks:
 
 - [x] Add `engine.movement` for selecting a camel and every camel above it,
-      placing stacks, updating positions, racing-camel clockwise movement,
-      crazy-camel counterclockwise movement, and finish-line handling.
+      placing stacks, updating positions, racing-camel forward movement,
+      crazy-camel backward movement, and finish-line handling.
 - [x] Resolve a grey die's printed camel to the moving crazy camel, including
       the passenger and stacked-crazy-camel overrides.
 - [x] Place normally moving camel units above the destination stack; defer the
@@ -293,21 +293,20 @@ Tasks:
 - [x] Keep movement functions free of random selection, terminal input, and
       terminal output.
 - [x] Add concrete movement tests for stack ordering, moving a camel with
-      camels above it, crazy-camel counterclockwise movement, and finish-line
-      behavior.
+      camels above it, crazy-camel backward movement, and finish-line behavior.
 
 Acceptance criteria:
 
 - Moving a camel preserves the order of the carried stack.
-- Crazy camel counterclockwise movement and grey-die overrides are explicitly
+- Crazy camel backward movement and grey-die overrides are explicitly
   tested.
 - Source and destination stack levels remain contiguous after every move.
 - All documented checks pass.
 
 Review focus:
 
-- Clockwise and counterclockwise placement, carried-stack semantics,
-  finish-line boundaries, and immutable board replacement.
+- Forward and backward placement, carried-stack semantics, finish-line
+  boundaries, and immutable board replacement.
 
 Non-goals:
 

--- a/docs/software-foundation-plan.md
+++ b/docs/software-foundation-plan.md
@@ -290,10 +290,11 @@ Tasks:
       the passenger and stacked-crazy-camel overrides.
 - [x] Place normally moving camel units above the destination stack; defer the
       under-stack rule for booing spectator tiles to the tile-rules PR.
-- [x] Keep movement functions free of random selection, terminal input, and
-      terminal output.
+- [x] Keep movement functions free of random selection, reject terminal input,
+      and mark finish crossing terminal in the returned state.
 - [x] Add concrete movement tests for stack ordering, moving a camel with
-      camels above it, crazy-camel backward movement, and finish-line behavior.
+      camels above it, both grey-die exceptions, crazy-camel backward movement,
+      and exact or overshooting finish-line crossings.
 
 Acceptance criteria:
 
@@ -522,7 +523,7 @@ High-priority areas:
 - [ ] Spectator tile placement constraints.
 - [ ] Spectator tile movement effects.
 - [ ] Leg reset behavior.
-- [ ] End-of-game detection.
+- [x] End-of-game detection.
 - [ ] Winner and runner-up ordering.
 - [ ] Legal actions and legal action masks.
 - [x] Determinism with fixed seeds.

--- a/docs/software-foundation-plan.md
+++ b/docs/software-foundation-plan.md
@@ -274,7 +274,7 @@ Non-goals:
 
 #### PR 3: `refactor: add immutable stack movement rules`
 
-Status: `Todo`
+Status: `Done`
 
 Suggested branch: `chore/immutable-stack-movement`
 
@@ -283,16 +283,16 @@ using the stable state and dice results from PR 2.
 
 Tasks:
 
-- [ ] Add `engine.movement` for selecting a camel and every camel above it,
+- [x] Add `engine.movement` for selecting a camel and every camel above it,
       placing stacks, updating positions, racing-camel clockwise movement,
       crazy-camel counterclockwise movement, and finish-line handling.
-- [ ] Resolve a grey die's printed camel to the moving crazy camel, including
+- [x] Resolve a grey die's printed camel to the moving crazy camel, including
       the passenger and stacked-crazy-camel overrides.
-- [ ] Place normally moving camel units above the destination stack; defer the
+- [x] Place normally moving camel units above the destination stack; defer the
       under-stack rule for booing spectator tiles to the tile-rules PR.
-- [ ] Keep movement functions free of random selection, terminal input, and
+- [x] Keep movement functions free of random selection, terminal input, and
       terminal output.
-- [ ] Add concrete movement tests for stack ordering, moving a camel with
+- [x] Add concrete movement tests for stack ordering, moving a camel with
       camels above it, crazy-camel counterclockwise movement, and finish-line
       behavior.
 
@@ -491,7 +491,7 @@ Tasks:
 - [x] Inject or store `random.Random` instead of using global `random`.
 - [x] Remove printing and user input from engine logic.
 - [x] Make dice rolling deterministic under a fixed seed.
-- [ ] Preserve camel stack ordering semantics.
+- [x] Preserve camel stack ordering semantics.
 - [ ] Define clear rule functions for movement, tile effects, leg reset, and
       game end.
 
@@ -516,10 +516,10 @@ Goal: Build confidence around high-risk game rules with focused tests.
 
 High-priority areas:
 
-- [ ] Camel stack ordering.
-- [ ] Moving a camel with camels above it.
-- [ ] Crazy camel backward movement.
-- [ ] Grey die behavior.
+- [x] Camel stack ordering.
+- [x] Moving a camel with camels above it.
+- [x] Crazy camel backward movement.
+- [x] Grey die behavior.
 - [ ] Spectator tile placement constraints.
 - [ ] Spectator tile movement effects.
 - [ ] Leg reset behavior.
@@ -614,7 +614,7 @@ The recommended first milestone is intentionally small and starts with CI:
       isolating the temporary mutable CLI adapter.
 - [ ] Update imports and CLI.
 - [ ] Expand Ruff and MyPy to check `src`.
-- [ ] Add focused tests for stack movement.
+- [x] Add focused tests for stack movement.
 - [x] Add focused tests for deterministic dice rolling and atomic setup.
 
 This milestone establishes the package foundation without attempting to

--- a/src/camel_up/engine/__init__.py
+++ b/src/camel_up/engine/__init__.py
@@ -7,6 +7,7 @@ from camel_up.engine.dice import (
     roll_die,
     setup_game,
 )
+from camel_up.engine.movement import move_camel
 from camel_up.engine.state import (
     CAMEL_ORDER,
     DIE_ORDER,
@@ -33,6 +34,7 @@ __all__ = [
     "SpectatorTile",
     "SetupRoll",
     "carried_camels",
+    "move_camel",
     "position_of",
     "reset_leg_dice",
     "roll_die",

--- a/src/camel_up/engine/dice.py
+++ b/src/camel_up/engine/dice.py
@@ -198,7 +198,7 @@ def _build_setup_board(
     stacks_by_space: dict[int, list[CamelId]] = {}
     for setup_roll in setup_rolls:
         if setup_roll.roll.die is DieId.GREY:
-            space = track_length - setup_roll.roll.distance - 1
+            space = track_length - setup_roll.roll.distance
         else:
             space = setup_roll.roll.distance - 1
         spaces_by_camel[setup_roll.placed_camel] = space

--- a/src/camel_up/engine/movement.py
+++ b/src/camel_up/engine/movement.py
@@ -19,16 +19,15 @@ from camel_up.engine.state import (
 )
 
 _CRAZY_CAMELS: Final = (CamelId.WHITE, CamelId.BLACK)
-_RACING_CAMELS: Final = frozenset(CAMEL_ORDER[:-2])
 
 
 def move_camel(state: GameState, roll: DieRoll) -> GameState:
     """Apply one physical die result to a fully set up game state.
 
     The selected camel carries every camel above it and the complete unit lands
-    on top of any destination stack. Racing camels move clockwise; crazy
-    camels move counterclockwise. Crossing either finish boundary clamps the
-    unit into that boundary's finish zone and makes the game terminal.
+    on top of any destination stack. Racing camels move forward; crazy camels
+    move backward. Crossing either finish boundary clamps the unit into that
+    boundary's finish zone and makes the game terminal.
 
     Dice selection and removal are handled by :func:`roll_die`; this function
     only applies the deterministic movement caused by ``roll``.
@@ -50,8 +49,10 @@ def move_camel(state: GameState, roll: DieRoll) -> GameState:
     if source.space is None:
         raise ValueError("moving camel must be placed")
 
-    direction = -1 if moving_camel in _CRAZY_CAMELS else 1
-    raw_destination = source.space + direction * roll.distance
+    movement_distance = roll.distance
+    if moving_camel in _CRAZY_CAMELS:
+        movement_distance = -movement_distance
+    raw_destination = source.space + movement_distance
     destination, crossed_finish = _resolve_finish_zone(
         raw_destination,
         state.board.track_length,
@@ -76,36 +77,56 @@ def move_camel(state: GameState, roll: DieRoll) -> GameState:
 
 
 def _resolve_moving_camel(board: BoardState, roll: DieRoll) -> CamelId:
-    """Resolve the grey die's passenger and stacked-camel exceptions."""
+    """Resolve the grey die's passenger and stacked-camel exceptions in order."""
     if roll.die is not DieId.GREY:
         return roll.camel
 
-    passenger_carriers = tuple(
-        camel
-        for camel in _CRAZY_CAMELS
-        if any(
-            passenger in _RACING_CAMELS
-            for passenger in carried_camels(board, camel)[1:]
-        )
-    )
-    if len(passenger_carriers) == 1:
-        return passenger_carriers[0]
+    only_passenger_carrier = _only_crazy_camel_with_racing_passengers(board)
+    if only_passenger_carrier is not None:
+        return only_passenger_carrier
 
-    white_position = position_of(board, CamelId.WHITE)
-    black_position = position_of(board, CamelId.BLACK)
-    if (
-        white_position.space == black_position.space
-        and white_position.level is not None
-        and black_position.level is not None
-        and abs(white_position.level - black_position.level) == 1
-    ):
-        return (
-            CamelId.WHITE
-            if white_position.level > black_position.level
-            else CamelId.BLACK
-        )
+    upper_crazy_camel = _upper_directly_stacked_crazy_camel(board)
+    if upper_crazy_camel is not None:
+        return upper_crazy_camel
 
     return roll.camel
+
+
+def _only_crazy_camel_with_racing_passengers(
+    board: BoardState,
+) -> CamelId | None:
+    """Return the sole crazy camel carrying racers, if there is exactly one."""
+    carriers = [
+        crazy_camel
+        for crazy_camel in _CRAZY_CAMELS
+        if _has_racing_passenger(board, crazy_camel)
+    ]
+
+    if len(carriers) != 1:
+        return None
+    return carriers[0]
+
+
+def _has_racing_passenger(board: BoardState, crazy_camel: CamelId) -> bool:
+    """Return whether a racing camel sits anywhere above ``crazy_camel``."""
+    passengers = carried_camels(board, crazy_camel)[1:]
+    return any(passenger not in _CRAZY_CAMELS for passenger in passengers)
+
+
+def _upper_directly_stacked_crazy_camel(board: BoardState) -> CamelId | None:
+    """Return the upper crazy camel when both are adjacent in one stack."""
+    white_position = position_of(board, CamelId.WHITE)
+    black_position = position_of(board, CamelId.BLACK)
+    if white_position.space != black_position.space:
+        return None
+    if white_position.level is None or black_position.level is None:
+        return None
+    if abs(white_position.level - black_position.level) != 1:
+        return None
+
+    if white_position.level > black_position.level:
+        return CamelId.WHITE
+    return CamelId.BLACK
 
 
 def _resolve_finish_zone(destination: int, track_length: int) -> tuple[int, bool]:

--- a/src/camel_up/engine/movement.py
+++ b/src/camel_up/engine/movement.py
@@ -49,10 +49,10 @@ def move_camel(state: GameState, roll: DieRoll) -> GameState:
     if source.space is None:
         raise ValueError("moving camel must be placed")
 
-    movement_distance = roll.distance
     if moving_camel in _CRAZY_CAMELS:
-        movement_distance = -movement_distance
-    raw_destination = source.space + movement_distance
+        raw_destination = source.space - roll.distance
+    else:
+        raw_destination = source.space + roll.distance
     destination, crossed_finish = _resolve_finish_zone(
         raw_destination,
         state.board.track_length,

--- a/src/camel_up/engine/movement.py
+++ b/src/camel_up/engine/movement.py
@@ -1,0 +1,125 @@
+"""Deterministic, immutable camel stack movement rules."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Final
+
+from camel_up.engine.dice import DieRoll
+from camel_up.engine.state import (
+    CAMEL_ORDER,
+    BoardState,
+    CamelId,
+    CamelPosition,
+    DieId,
+    GameState,
+    carried_camels,
+    position_of,
+    stack_at,
+)
+
+_CRAZY_CAMELS: Final = (CamelId.WHITE, CamelId.BLACK)
+_RACING_CAMELS: Final = frozenset(CAMEL_ORDER[:-2])
+
+
+def move_camel(state: GameState, roll: DieRoll) -> GameState:
+    """Apply one physical die result to a fully set up game state.
+
+    The selected camel carries every camel above it and the complete unit lands
+    on top of any destination stack. Racing camels move clockwise; crazy
+    camels move counterclockwise. Crossing either finish boundary clamps the
+    unit into that boundary's finish zone and makes the game terminal.
+
+    Dice selection and removal are handled by :func:`roll_die`; this function
+    only applies the deterministic movement caused by ``roll``.
+
+    Args:
+        state: A non-terminal state with all seven camels placed.
+        roll: The physical die result whose movement should be applied.
+
+    Returns:
+        A replacement state containing the moved camel unit.
+
+    Raises:
+        ValueError: If setup is incomplete, the game is terminal, or the move
+            requires a spectator-tile effect that is not implemented yet.
+    """
+    _validate_movement_state(state)
+    moving_camel = _resolve_moving_camel(state.board, roll)
+    source = position_of(state.board, moving_camel)
+    if source.space is None:
+        raise ValueError("moving camel must be placed")
+
+    direction = -1 if moving_camel in _CRAZY_CAMELS else 1
+    raw_destination = source.space + direction * roll.distance
+    destination, crossed_finish = _resolve_finish_zone(
+        raw_destination,
+        state.board.track_length,
+    )
+    if not crossed_finish and any(
+        tile.space == destination for tile in state.board.spectator_tiles
+    ):
+        raise ValueError("spectator tile movement effects are not implemented")
+
+    moving_unit = carried_camels(state.board, moving_camel)
+    destination_level = len(stack_at(state.board, destination))
+    positions = list(state.board.camel_positions)
+    for level_offset, camel in enumerate(moving_unit):
+        camel_index = CAMEL_ORDER.index(camel)
+        positions[camel_index] = CamelPosition(
+            space=destination,
+            level=destination_level + level_offset,
+        )
+
+    board = replace(state.board, camel_positions=tuple(positions))
+    return replace(state, board=board, terminal=crossed_finish)
+
+
+def _resolve_moving_camel(board: BoardState, roll: DieRoll) -> CamelId:
+    """Resolve the grey die's passenger and stacked-camel exceptions."""
+    if roll.die is not DieId.GREY:
+        return roll.camel
+
+    passenger_carriers = tuple(
+        camel
+        for camel in _CRAZY_CAMELS
+        if any(
+            passenger in _RACING_CAMELS
+            for passenger in carried_camels(board, camel)[1:]
+        )
+    )
+    if len(passenger_carriers) == 1:
+        return passenger_carriers[0]
+
+    white_position = position_of(board, CamelId.WHITE)
+    black_position = position_of(board, CamelId.BLACK)
+    if (
+        white_position.space == black_position.space
+        and white_position.level is not None
+        and black_position.level is not None
+        and abs(white_position.level - black_position.level) == 1
+    ):
+        return (
+            CamelId.WHITE
+            if white_position.level > black_position.level
+            else CamelId.BLACK
+        )
+
+    return roll.camel
+
+
+def _resolve_finish_zone(destination: int, track_length: int) -> tuple[int, bool]:
+    """Clamp a crossing move to the appropriate terminal finish zone."""
+    if destination < 0:
+        return -1, True
+    if destination >= track_length:
+        return track_length, True
+    return destination, False
+
+
+def _validate_movement_state(state: GameState) -> None:
+    """Reject invalid movement inputs before constructing a replacement."""
+    if not all(position.is_placed for position in state.board.camel_positions):
+        raise ValueError("initial setup must be completed before moving")
+    if state.terminal:
+        raise ValueError("cannot move a camel after the game has ended")

--- a/src/camel_up/engine/state.py
+++ b/src/camel_up/engine/state.py
@@ -43,8 +43,10 @@ class CamelPosition:
     """A camel's coordinate on the track and within its stack.
 
     Level zero is the bottom of a stack. An unplaced camel has both fields set
-    to ``None``. Positions are the sole source of truth for camel placement;
-    board stacks are derived from them.
+    to ``None``. Finish zones use space ``-1`` for counterclockwise crossing
+    and ``BoardState.track_length`` for clockwise crossing. Positions are the
+    sole source of truth for camel placement; board stacks are derived from
+    them.
     """
 
     space: int | None = None
@@ -54,8 +56,8 @@ class CamelPosition:
         """Require a complete placed or unplaced coordinate."""
         if (self.space is None) != (self.level is None):
             raise ValueError("space and level must either both be set or both be None")
-        if self.space is not None and self.space < 0:
-            raise ValueError("space must be non-negative")
+        if self.space is not None and self.space < -1:
+            raise ValueError("space cannot be before the counterclockwise finish zone")
         if self.level is not None and self.level < 0:
             raise ValueError("level must be non-negative")
 
@@ -87,9 +89,11 @@ class SpectatorTile:
 class BoardState:
     """Immutable track state with camel coordinates and spectator tiles.
 
+    ``track_length`` is the number of playable spaces, indexed from zero.
     ``camel_positions`` uses :data:`CAMEL_ORDER`; its index is the camel's
     identity. Camels on the same space must occupy unique, contiguous levels
-    beginning at zero. ``spectator_tiles`` is ordered by ``player_id`` so that
+    beginning at zero. A terminal camel unit may occupy finish zone ``-1`` or
+    ``track_length``. ``spectator_tiles`` is ordered by ``player_id`` so that
     logically equivalent snapshots compare and hash identically. A snapshot
     contains either no placed camels before setup or all camels after setup;
     initial placement is committed as one atomic state transition.
@@ -100,7 +104,7 @@ class BoardState:
     spectator_tiles: tuple[SpectatorTile, ...] = ()
 
     @classmethod
-    def empty(cls, track_length: int = 17) -> BoardState:
+    def empty(cls, track_length: int = 16) -> BoardState:
         """Create the deterministic board state before initial dice rolls.
 
         Starting camel positions depend on random die outcomes. The future
@@ -131,8 +135,8 @@ class BoardState:
             if position.space is None or position.level is None:
                 continue
             placed_count += 1
-            if position.space >= self.track_length:
-                raise ValueError("camel space must be within the track")
+            if position.space > self.track_length:
+                raise ValueError("camel space cannot pass a finish zone")
             levels_by_space.setdefault(position.space, []).append(position.level)
 
         if placed_count not in (0, len(CAMEL_ORDER)):
@@ -187,7 +191,7 @@ class GameState:
     terminal: bool = False
 
     @classmethod
-    def pre_setup(cls, track_length: int = 17) -> GameState:
+    def pre_setup(cls, track_length: int = 16) -> GameState:
         """Create a state awaiting seeded initial camel placement."""
         return cls(board=BoardState.empty(track_length))
 
@@ -202,6 +206,11 @@ class GameState:
             raise ValueError("current_player must be non-negative")
         if self.leg_number < 1:
             raise ValueError("leg_number must be positive")
+        if not self.terminal and any(
+            position.space in (-1, self.board.track_length)
+            for position in self.board.camel_positions
+        ):
+            raise ValueError("a camel in a finish zone requires a terminal game")
 
 
 def position_of(board: BoardState, camel: CamelId) -> CamelPosition:
@@ -211,8 +220,8 @@ def position_of(board: BoardState, camel: CamelId) -> CamelPosition:
 
 def stack_at(board: BoardState, space: int) -> tuple[CamelId, ...]:
     """Return the stack at ``space`` ordered from bottom to top."""
-    if not 0 <= space < board.track_length:
-        raise ValueError("space must be within the track")
+    if not -1 <= space <= board.track_length:
+        raise ValueError("space must be on the track or in a finish zone")
 
     stack: list[tuple[int, CamelId]] = []
     for camel, position in zip(CAMEL_ORDER, board.camel_positions, strict=True):

--- a/src/camel_up/engine/state.py
+++ b/src/camel_up/engine/state.py
@@ -43,10 +43,9 @@ class CamelPosition:
     """A camel's coordinate on the track and within its stack.
 
     Level zero is the bottom of a stack. An unplaced camel has both fields set
-    to ``None``. Finish zones use space ``-1`` for counterclockwise crossing
-    and ``BoardState.track_length`` for clockwise crossing. Positions are the
-    sole source of truth for camel placement; board stacks are derived from
-    them.
+    to ``None``. Finish zones use space ``-1`` for backward crossing and
+    ``BoardState.track_length`` for forward crossing. Positions are the sole
+    source of truth for camel placement; board stacks are derived from them.
     """
 
     space: int | None = None
@@ -57,7 +56,7 @@ class CamelPosition:
         if (self.space is None) != (self.level is None):
             raise ValueError("space and level must either both be set or both be None")
         if self.space is not None and self.space < -1:
-            raise ValueError("space cannot be before the counterclockwise finish zone")
+            raise ValueError("space cannot be before the backward finish zone")
         if self.level is not None and self.level < 0:
             raise ValueError("level must be non-negative")
 

--- a/tests/engine/test_dice.py
+++ b/tests/engine/test_dice.py
@@ -158,7 +158,7 @@ def test_initial_setup_rolls_define_positions_and_stack_order() -> None:
     expected_stacks: dict[int, list[CamelId]] = {}
     for setup_roll in rolls:
         space = (
-            state.board.track_length - setup_roll.roll.distance - 1
+            state.board.track_length - setup_roll.roll.distance
             if setup_roll.roll.die is DieId.GREY
             else setup_roll.roll.distance - 1
         )
@@ -211,7 +211,7 @@ def test_setup_position_tuple_matches_canonical_camel_order() -> None:
     expected_levels_by_space: dict[int, int] = {}
     for setup_roll in setup_rolls:
         space = (
-            state.board.track_length - setup_roll.roll.distance - 1
+            state.board.track_length - setup_roll.roll.distance
             if setup_roll.roll.die is DieId.GREY
             else setup_roll.roll.distance - 1
         )

--- a/tests/engine/test_movement.py
+++ b/tests/engine/test_movement.py
@@ -20,9 +20,9 @@ from camel_up.engine import (
 def _state_with_stacks(
     stacks: dict[int, tuple[CamelId, ...]],
     *,
-    open_spaces: tuple[int, ...] = (),
     spectator_tiles: tuple[SpectatorTile, ...] = (),
 ) -> GameState:
+    """Build a state from complete bottom-to-top stack definitions."""
     positions_by_camel: dict[CamelId, CamelPosition] = {}
     for space, stack in stacks.items():
         for level, camel in enumerate(stack):
@@ -30,15 +30,8 @@ def _state_with_stacks(
                 raise ValueError("test stacks cannot place a camel more than once")
             positions_by_camel[camel] = CamelPosition(space=space, level=level)
 
-    reserved_spaces = set(stacks) | set(open_spaces)
-    reserved_spaces.update(tile.space for tile in spectator_tiles)
-    filler_spaces = (space for space in range(16) if space not in reserved_spaces)
-    for camel in CAMEL_ORDER:
-        if camel not in positions_by_camel:
-            positions_by_camel[camel] = CamelPosition(
-                space=next(filler_spaces),
-                level=0,
-            )
+    if set(positions_by_camel) != set(CAMEL_ORDER):
+        raise ValueError("test stacks must place every camel exactly once")
     positions = tuple(positions_by_camel[camel] for camel in CAMEL_ORDER)
     return GameState(
         board=BoardState(
@@ -54,6 +47,8 @@ def test_racing_camel_carries_upper_stack_onto_destination_stack() -> None:
         {
             3: (CamelId.GREEN, CamelId.RED, CamelId.BLUE),
             5: (CamelId.BLACK, CamelId.PURPLE),
+            8: (CamelId.YELLOW,),
+            12: (CamelId.WHITE,),
         }
     )
 
@@ -80,8 +75,11 @@ def test_racing_camel_carries_upper_stack_onto_destination_stack() -> None:
 def test_crazy_camel_moves_backward_with_its_passengers() -> None:
     state = _state_with_stacks(
         {
+            4: (CamelId.YELLOW,),
+            5: (CamelId.PURPLE,),
             8: (CamelId.GREEN,),
             10: (CamelId.WHITE, CamelId.RED, CamelId.BLUE),
+            14: (CamelId.BLACK,),
         }
     )
 
@@ -102,10 +100,13 @@ def test_crazy_camel_moves_backward_with_its_passengers() -> None:
 def test_grey_die_moves_only_crazy_camel_carrying_racing_passengers() -> None:
     state = _state_with_stacks(
         {
+            3: (CamelId.BLUE,),
+            4: (CamelId.GREEN,),
+            5: (CamelId.YELLOW,),
+            6: (CamelId.PURPLE,),
             10: (CamelId.WHITE, CamelId.RED),
             14: (CamelId.BLACK,),
-        },
-        open_spaces=(9,),
+        }
     )
 
     next_state = move_camel(
@@ -123,9 +124,12 @@ def test_grey_die_moves_only_crazy_camel_carrying_racing_passengers() -> None:
 def test_grey_die_moves_upper_crazy_camel_when_they_are_directly_stacked() -> None:
     state = _state_with_stacks(
         {
+            3: (CamelId.BLUE,),
+            4: (CamelId.GREEN,),
+            5: (CamelId.YELLOW,),
+            6: (CamelId.PURPLE,),
             10: (CamelId.WHITE, CamelId.BLACK, CamelId.RED),
-        },
-        open_spaces=(9,),
+        }
     )
 
     next_state = move_camel(
@@ -140,10 +144,14 @@ def test_grey_die_moves_upper_crazy_camel_when_they_are_directly_stacked() -> No
 def test_grey_die_uses_printed_camel_when_no_exception_applies() -> None:
     state = _state_with_stacks(
         {
+            3: (CamelId.RED,),
+            4: (CamelId.BLUE,),
+            5: (CamelId.GREEN,),
+            6: (CamelId.YELLOW,),
+            7: (CamelId.PURPLE,),
             10: (CamelId.WHITE,),
             14: (CamelId.BLACK,),
-        },
-        open_spaces=(12,),
+        }
     )
 
     next_state = move_camel(
@@ -158,10 +166,12 @@ def test_grey_die_uses_printed_camel_when_no_exception_applies() -> None:
 def test_grey_die_uses_printed_camel_when_both_crazy_camels_carry_racers() -> None:
     state = _state_with_stacks(
         {
+            3: (CamelId.GREEN,),
+            4: (CamelId.YELLOW,),
+            5: (CamelId.PURPLE,),
             10: (CamelId.WHITE, CamelId.RED),
             14: (CamelId.BLACK, CamelId.BLUE),
-        },
-        open_spaces=(13,),
+        }
     )
 
     next_state = move_camel(
@@ -176,6 +186,11 @@ def test_grey_die_uses_printed_camel_when_both_crazy_camels_carry_racers() -> No
 def test_forward_finish_crossing_moves_unit_to_finish_zone() -> None:
     state = _state_with_stacks(
         {
+            3: (CamelId.GREEN,),
+            4: (CamelId.YELLOW,),
+            5: (CamelId.PURPLE,),
+            10: (CamelId.WHITE,),
+            12: (CamelId.BLACK,),
             14: (CamelId.RED, CamelId.BLUE),
         }
     )
@@ -193,6 +208,9 @@ def test_backward_finish_crossing_preserves_last_place_stack_order() -> None:
     state = _state_with_stacks(
         {
             1: (CamelId.WHITE, CamelId.RED, CamelId.BLUE),
+            4: (CamelId.GREEN,),
+            5: (CamelId.YELLOW,),
+            6: (CamelId.PURPLE,),
             12: (CamelId.BLACK,),
         }
     )
@@ -214,6 +232,12 @@ def test_crazy_camel_crossing_finish_alone_still_ends_game() -> None:
     state = _state_with_stacks(
         {
             0: (CamelId.WHITE,),
+            3: (CamelId.RED,),
+            4: (CamelId.BLUE,),
+            5: (CamelId.GREEN,),
+            6: (CamelId.YELLOW,),
+            7: (CamelId.PURPLE,),
+            12: (CamelId.BLACK,),
         }
     )
 
@@ -231,7 +255,17 @@ def test_movement_rejects_incomplete_or_terminal_game() -> None:
     with pytest.raises(ValueError, match="setup must be completed"):
         move_camel(GameState.pre_setup(), roll)
 
-    state = _state_with_stacks({})
+    state = _state_with_stacks(
+        {
+            3: (CamelId.RED,),
+            4: (CamelId.BLUE,),
+            5: (CamelId.GREEN,),
+            6: (CamelId.YELLOW,),
+            7: (CamelId.PURPLE,),
+            10: (CamelId.WHITE,),
+            12: (CamelId.BLACK,),
+        }
+    )
     with pytest.raises(ValueError, match="game has ended"):
         move_camel(replace(state, terminal=True), roll)
 
@@ -239,7 +273,13 @@ def test_movement_rejects_incomplete_or_terminal_game() -> None:
 def test_movement_defers_spectator_tile_effects_explicitly() -> None:
     state = _state_with_stacks(
         {
+            3: (CamelId.RED,),
+            4: (CamelId.BLUE,),
+            5: (CamelId.GREEN,),
+            6: (CamelId.YELLOW,),
             7: (CamelId.PURPLE,),
+            10: (CamelId.WHITE,),
+            12: (CamelId.BLACK,),
         },
         spectator_tiles=(SpectatorTile(player_id=0, space=8, effect=1),),
     )

--- a/tests/engine/test_movement.py
+++ b/tests/engine/test_movement.py
@@ -1,0 +1,238 @@
+from dataclasses import replace
+
+import pytest
+
+from camel_up.engine import (
+    CAMEL_ORDER,
+    BoardState,
+    CamelId,
+    CamelPosition,
+    DieId,
+    DieRoll,
+    GameState,
+    SpectatorTile,
+    move_camel,
+    position_of,
+    stack_at,
+)
+
+
+def _state_with_stacks(
+    stacks: dict[int, tuple[CamelId, ...]],
+    *,
+    open_spaces: tuple[int, ...] = (),
+    spectator_tiles: tuple[SpectatorTile, ...] = (),
+) -> GameState:
+    positions_by_camel = {
+        camel: CamelPosition(space=space, level=level)
+        for space, stack in stacks.items()
+        for level, camel in enumerate(stack)
+    }
+    explicitly_placed = [camel for stack in stacks.values() for camel in stack]
+    if len(explicitly_placed) != len(set(explicitly_placed)):
+        raise ValueError("test stacks cannot place a camel more than once")
+
+    reserved_spaces = {
+        *stacks,
+        *open_spaces,
+        *(tile.space for tile in spectator_tiles),
+    }
+    filler_spaces = (space for space in range(16) if space not in reserved_spaces)
+    for camel in CAMEL_ORDER:
+        if camel not in positions_by_camel:
+            positions_by_camel[camel] = CamelPosition(
+                space=next(filler_spaces),
+                level=0,
+            )
+    positions = tuple(positions_by_camel[camel] for camel in CAMEL_ORDER)
+    return GameState(
+        board=BoardState(
+            track_length=16,
+            camel_positions=positions,
+            spectator_tiles=spectator_tiles,
+        )
+    )
+
+
+def test_racing_camel_carries_upper_stack_onto_destination_stack() -> None:
+    state = _state_with_stacks(
+        {
+            3: (CamelId.GREEN, CamelId.RED, CamelId.BLUE),
+            5: (CamelId.BLACK, CamelId.PURPLE),
+        }
+    )
+
+    next_state = move_camel(
+        state,
+        DieRoll(die=DieId.RED, camel=CamelId.RED, distance=2),
+    )
+
+    assert stack_at(next_state.board, 3) == (CamelId.GREEN,)
+    assert stack_at(next_state.board, 5) == (
+        CamelId.BLACK,
+        CamelId.PURPLE,
+        CamelId.RED,
+        CamelId.BLUE,
+    )
+    assert state != next_state
+    assert stack_at(state.board, 3) == (
+        CamelId.GREEN,
+        CamelId.RED,
+        CamelId.BLUE,
+    )
+
+
+def test_crazy_camel_moves_counterclockwise_with_its_passengers() -> None:
+    state = _state_with_stacks(
+        {
+            8: (CamelId.GREEN,),
+            10: (CamelId.WHITE, CamelId.RED, CamelId.BLUE),
+        }
+    )
+
+    next_state = move_camel(
+        state,
+        DieRoll(die=DieId.GREY, camel=CamelId.WHITE, distance=2),
+    )
+
+    assert stack_at(next_state.board, 10) == ()
+    assert stack_at(next_state.board, 8) == (
+        CamelId.GREEN,
+        CamelId.WHITE,
+        CamelId.RED,
+        CamelId.BLUE,
+    )
+
+
+def test_grey_die_moves_only_crazy_camel_carrying_racing_passengers() -> None:
+    state = _state_with_stacks(
+        {
+            10: (CamelId.WHITE, CamelId.RED),
+            14: (CamelId.BLACK,),
+        },
+        open_spaces=(9,),
+    )
+
+    next_state = move_camel(
+        state,
+        DieRoll(die=DieId.GREY, camel=CamelId.BLACK, distance=1),
+    )
+
+    assert stack_at(next_state.board, 9) == (CamelId.WHITE, CamelId.RED)
+    assert position_of(next_state.board, CamelId.BLACK) == CamelPosition(
+        space=14,
+        level=0,
+    )
+
+
+def test_grey_die_moves_upper_crazy_camel_when_they_are_directly_stacked() -> None:
+    state = _state_with_stacks(
+        {
+            10: (CamelId.WHITE, CamelId.BLACK, CamelId.RED),
+        },
+        open_spaces=(9,),
+    )
+
+    next_state = move_camel(
+        state,
+        DieRoll(die=DieId.GREY, camel=CamelId.WHITE, distance=1),
+    )
+
+    assert stack_at(next_state.board, 10) == (CamelId.WHITE,)
+    assert stack_at(next_state.board, 9) == (CamelId.BLACK, CamelId.RED)
+
+
+def test_grey_die_uses_printed_camel_when_no_exception_applies() -> None:
+    state = _state_with_stacks(
+        {
+            10: (CamelId.WHITE,),
+            14: (CamelId.BLACK,),
+        },
+        open_spaces=(12,),
+    )
+
+    next_state = move_camel(
+        state,
+        DieRoll(die=DieId.GREY, camel=CamelId.BLACK, distance=2),
+    )
+
+    assert position_of(next_state.board, CamelId.BLACK).space == 12
+    assert position_of(next_state.board, CamelId.WHITE).space == 10
+
+
+def test_clockwise_finish_crossing_moves_unit_to_finish_zone() -> None:
+    state = _state_with_stacks(
+        {
+            14: (CamelId.RED, CamelId.BLUE),
+        }
+    )
+
+    next_state = move_camel(
+        state,
+        DieRoll(die=DieId.RED, camel=CamelId.RED, distance=2),
+    )
+
+    assert next_state.terminal
+    assert stack_at(next_state.board, 16) == (CamelId.RED, CamelId.BLUE)
+
+
+def test_counterclockwise_finish_preserves_last_place_stack_order() -> None:
+    state = _state_with_stacks(
+        {
+            1: (CamelId.WHITE, CamelId.RED, CamelId.BLUE),
+            12: (CamelId.BLACK,),
+        }
+    )
+
+    next_state = move_camel(
+        state,
+        DieRoll(die=DieId.GREY, camel=CamelId.WHITE, distance=2),
+    )
+
+    assert next_state.terminal
+    assert stack_at(next_state.board, -1) == (
+        CamelId.WHITE,
+        CamelId.RED,
+        CamelId.BLUE,
+    )
+
+
+def test_crazy_camel_crossing_finish_alone_still_ends_game() -> None:
+    state = _state_with_stacks(
+        {
+            0: (CamelId.WHITE,),
+        }
+    )
+
+    next_state = move_camel(
+        state,
+        DieRoll(die=DieId.GREY, camel=CamelId.WHITE, distance=1),
+    )
+
+    assert next_state.terminal
+    assert stack_at(next_state.board, -1) == (CamelId.WHITE,)
+
+
+def test_movement_rejects_incomplete_or_terminal_game() -> None:
+    roll = DieRoll(die=DieId.RED, camel=CamelId.RED, distance=1)
+    with pytest.raises(ValueError, match="setup must be completed"):
+        move_camel(GameState.pre_setup(), roll)
+
+    state = _state_with_stacks({})
+    with pytest.raises(ValueError, match="game has ended"):
+        move_camel(replace(state, terminal=True), roll)
+
+
+def test_movement_defers_spectator_tile_effects_explicitly() -> None:
+    state = _state_with_stacks(
+        {
+            7: (CamelId.PURPLE,),
+        },
+        spectator_tiles=(SpectatorTile(player_id=0, space=8, effect=1),),
+    )
+
+    with pytest.raises(ValueError, match="tile movement effects"):
+        move_camel(
+            state,
+            DieRoll(die=DieId.PURPLE, camel=CamelId.PURPLE, distance=1),
+        )

--- a/tests/engine/test_movement.py
+++ b/tests/engine/test_movement.py
@@ -183,6 +183,35 @@ def test_grey_die_uses_printed_camel_when_both_crazy_camels_carry_racers() -> No
     assert stack_at(next_state.board, 13) == (CamelId.BLACK, CamelId.BLUE)
 
 
+def test_grey_die_uses_printed_camel_when_crazy_camels_are_separated_in_stack() -> None:
+    state = _state_with_stacks(
+        {
+            3: (CamelId.GREEN,),
+            4: (CamelId.YELLOW,),
+            5: (CamelId.PURPLE,),
+            10: (
+                CamelId.BLACK,
+                CamelId.RED,
+                CamelId.WHITE,
+                CamelId.BLUE,
+            ),
+        }
+    )
+
+    next_state = move_camel(
+        state,
+        DieRoll(die=DieId.GREY, camel=CamelId.BLACK, distance=1),
+    )
+
+    assert stack_at(next_state.board, 10) == ()
+    assert stack_at(next_state.board, 9) == (
+        CamelId.BLACK,
+        CamelId.RED,
+        CamelId.WHITE,
+        CamelId.BLUE,
+    )
+
+
 def test_forward_finish_crossing_moves_unit_to_finish_zone() -> None:
     state = _state_with_stacks(
         {
@@ -202,6 +231,29 @@ def test_forward_finish_crossing_moves_unit_to_finish_zone() -> None:
 
     assert next_state.terminal
     assert stack_at(next_state.board, 16) == (CamelId.RED, CamelId.BLUE)
+
+
+def test_forward_finish_overshoot_clamps_unit_to_finish_zone() -> None:
+    state = _state_with_stacks(
+        {
+            3: (CamelId.BLUE,),
+            4: (CamelId.GREEN,),
+            5: (CamelId.YELLOW,),
+            6: (CamelId.PURPLE,),
+            10: (CamelId.WHITE,),
+            12: (CamelId.BLACK,),
+            15: (CamelId.RED,),
+        }
+    )
+
+    next_state = move_camel(
+        state,
+        DieRoll(die=DieId.RED, camel=CamelId.RED, distance=3),
+    )
+
+    assert next_state.terminal
+    assert stack_at(next_state.board, 15) == ()
+    assert stack_at(next_state.board, 16) == (CamelId.RED,)
 
 
 def test_backward_finish_crossing_preserves_last_place_stack_order() -> None:
@@ -226,6 +278,29 @@ def test_backward_finish_crossing_preserves_last_place_stack_order() -> None:
         CamelId.RED,
         CamelId.BLUE,
     )
+
+
+def test_backward_finish_overshoot_clamps_unit_to_finish_zone() -> None:
+    state = _state_with_stacks(
+        {
+            1: (CamelId.WHITE,),
+            3: (CamelId.RED,),
+            4: (CamelId.BLUE,),
+            5: (CamelId.GREEN,),
+            6: (CamelId.YELLOW,),
+            7: (CamelId.PURPLE,),
+            12: (CamelId.BLACK,),
+        }
+    )
+
+    next_state = move_camel(
+        state,
+        DieRoll(die=DieId.GREY, camel=CamelId.WHITE, distance=3),
+    )
+
+    assert next_state.terminal
+    assert stack_at(next_state.board, 1) == ()
+    assert stack_at(next_state.board, -1) == (CamelId.WHITE,)
 
 
 def test_crazy_camel_crossing_finish_alone_still_ends_game() -> None:

--- a/tests/engine/test_movement.py
+++ b/tests/engine/test_movement.py
@@ -23,20 +23,15 @@ def _state_with_stacks(
     open_spaces: tuple[int, ...] = (),
     spectator_tiles: tuple[SpectatorTile, ...] = (),
 ) -> GameState:
-    positions_by_camel = {
-        camel: CamelPosition(space=space, level=level)
-        for space, stack in stacks.items()
-        for level, camel in enumerate(stack)
-    }
-    explicitly_placed = [camel for stack in stacks.values() for camel in stack]
-    if len(explicitly_placed) != len(set(explicitly_placed)):
-        raise ValueError("test stacks cannot place a camel more than once")
+    positions_by_camel: dict[CamelId, CamelPosition] = {}
+    for space, stack in stacks.items():
+        for level, camel in enumerate(stack):
+            if camel in positions_by_camel:
+                raise ValueError("test stacks cannot place a camel more than once")
+            positions_by_camel[camel] = CamelPosition(space=space, level=level)
 
-    reserved_spaces = {
-        *stacks,
-        *open_spaces,
-        *(tile.space for tile in spectator_tiles),
-    }
+    reserved_spaces = set(stacks) | set(open_spaces)
+    reserved_spaces.update(tile.space for tile in spectator_tiles)
     filler_spaces = (space for space in range(16) if space not in reserved_spaces)
     for camel in CAMEL_ORDER:
         if camel not in positions_by_camel:
@@ -82,7 +77,7 @@ def test_racing_camel_carries_upper_stack_onto_destination_stack() -> None:
     )
 
 
-def test_crazy_camel_moves_counterclockwise_with_its_passengers() -> None:
+def test_crazy_camel_moves_backward_with_its_passengers() -> None:
     state = _state_with_stacks(
         {
             8: (CamelId.GREEN,),
@@ -160,7 +155,25 @@ def test_grey_die_uses_printed_camel_when_no_exception_applies() -> None:
     assert position_of(next_state.board, CamelId.WHITE).space == 10
 
 
-def test_clockwise_finish_crossing_moves_unit_to_finish_zone() -> None:
+def test_grey_die_uses_printed_camel_when_both_crazy_camels_carry_racers() -> None:
+    state = _state_with_stacks(
+        {
+            10: (CamelId.WHITE, CamelId.RED),
+            14: (CamelId.BLACK, CamelId.BLUE),
+        },
+        open_spaces=(13,),
+    )
+
+    next_state = move_camel(
+        state,
+        DieRoll(die=DieId.GREY, camel=CamelId.BLACK, distance=1),
+    )
+
+    assert stack_at(next_state.board, 10) == (CamelId.WHITE, CamelId.RED)
+    assert stack_at(next_state.board, 13) == (CamelId.BLACK, CamelId.BLUE)
+
+
+def test_forward_finish_crossing_moves_unit_to_finish_zone() -> None:
     state = _state_with_stacks(
         {
             14: (CamelId.RED, CamelId.BLUE),
@@ -176,7 +189,7 @@ def test_clockwise_finish_crossing_moves_unit_to_finish_zone() -> None:
     assert stack_at(next_state.board, 16) == (CamelId.RED, CamelId.BLUE)
 
 
-def test_counterclockwise_finish_preserves_last_place_stack_order() -> None:
+def test_backward_finish_crossing_preserves_last_place_stack_order() -> None:
     state = _state_with_stacks(
         {
             1: (CamelId.WHITE, CamelId.RED, CamelId.BLUE),

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -50,7 +50,7 @@ def test_pre_setup_game_has_one_unplaced_position_per_camel() -> None:
     state = GameState.pre_setup()
     expected_positions = tuple(CamelPosition() for _ in CAMEL_ORDER)
 
-    assert state.board.track_length == 17
+    assert state.board.track_length == 16
     assert state.board.camel_positions == expected_positions
     assert state.remaining_dice == DIE_ORDER
 
@@ -223,6 +223,18 @@ def test_game_states_are_hashable_and_replaceable_without_mutation() -> None:
     assert state.remaining_dice == DIE_ORDER
     assert transpositions[state] == "root"
     assert transpositions[next_state] == "child"
+
+
+def test_finish_zone_requires_terminal_game_state() -> None:
+    board = BoardState(
+        track_length=16,
+        camel_positions=_fully_placed_positions(),
+    )
+
+    with pytest.raises(ValueError, match="finish zone requires a terminal game"):
+        GameState(board=board)
+
+    assert GameState(board=board, terminal=True).terminal
 
 
 def test_legacy_components_preserve_prototype_stack_behavior() -> None:

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -113,6 +113,13 @@ def test_board_rejects_partial_camel_setup_snapshot() -> None:
         BoardState(track_length=17, camel_positions=tuple(positions))
 
 
+def test_board_rejects_missing_camel_position_entry() -> None:
+    positions = BoardState.empty().camel_positions[:-1]
+
+    with pytest.raises(ValueError, match="must contain 7 entries"):
+        BoardState(track_length=17, camel_positions=positions)
+
+
 def test_position_requires_both_coordinate_fields() -> None:
     with pytest.raises(ValueError, match="both be set"):
         CamelPosition(space=3)


### PR DESCRIPTION
## Outcome

Add deterministic, immutable camel-unit movement using the state and die-roll
contracts established by the preceding engine pull requests.

## What changed

- add move_camel as the public movement transition
- preserve carried-stack order and place normal movement above destination stacks
- move racing camels forward and crazy camels backward
- implement the grey die passenger and directly-stacked crazy-camel overrides
- represent forward and backward finish zones and terminate on crossing
- correct the default board model to 16 playable spaces
- add focused scenarios for stack movement, both grey-die exceptions, both finish
  directions, immutability, invalid states, and deferred spectator-tile effects
- update the public example and foundation roadmap

Review follow-up also splits grey-die selection into named rule helpers and
covers the case where both crazy camels carry racing passengers.

The finish-coordinate changes stay with movement because backward finish crossing
cannot be represented correctly by the previous non-negative, in-track-only model.
Most of the pull request is concrete rule-test coverage.

## Non-goals

- spectator-tile movement effects
- player state, betting, or scoring
- legal actions and turn orchestration
- CLI migration, agents, or RL environments

## Review focus

- carried-stack ordering and immutable board replacement
- grey-die override precedence
- 16-space track and two finish-zone boundaries
- backward-crossing order for racing camels carried by a crazy camel

## Verification

- uv run python -m pytest
- uv run ruff check .
- uv run ruff format --check .
- uv run python -m mypy
- explicit MyPy check of src/camel_up/engine
