### PR TITLE
chore: extend tooling checks to production code

### DIFF
--- a/docs/software-foundation-plan.md
+++ b/docs/software-foundation-plan.md
@@ -620,7 +620,7 @@ The recommended first milestone is intentionally small and starts with CI:
 - [x] Add canonical `CamelPosition`, `BoardState`, and `GameState` types while
       isolating the temporary mutable CLI adapter.
 - [ ] Update imports and CLI.
-- [ ] Expand Ruff and MyPy to check `src`.
+- [x] Expand Ruff and MyPy to check `src`.
 - [x] Add focused tests for stack movement.
 - [x] Add focused tests for deterministic dice rolling and atomic setup.
 

--- a/docs/software-foundation-plan.md
+++ b/docs/software-foundation-plan.md
@@ -437,8 +437,8 @@ Tasks:
 - [ ] Add or update CLI smoke tests and verify `uv run camel-up` still starts.
 - [ ] Remove `components.py`, root-level `main.py`, and
       `py-modules = ["components", "main"]` after all imports have migrated.
-- [ ] Configure Ruff to check `src` and `tests`.
-- [ ] Configure MyPy to check `src/camel_up` and `tests` with incremental
+- [x] Configure Ruff to check `src` and `tests`.
+- [x] Configure MyPy to check `src/camel_up` and `tests` with incremental
       strictness.
 - [ ] Update this plan and README examples to reflect the final package paths.
 
@@ -461,16 +461,16 @@ migration so it does not need to be rewritten around incomplete engine APIs.
 
 ## Phase 2: Tooling Baseline
 
-Status: `Todo`
+Status: `Done`
 
 Goal: Make formatting, linting, type checking, and tests cover production code.
 
 Tasks:
 
-- [ ] Configure Ruff to check `src` and `tests`.
-- [ ] Configure MyPy to check `src/camel_up` and `tests`.
-- [ ] Keep strictness incremental so refactors remain manageable.
-- [ ] Ensure all documented commands work:
+- [x] Configure Ruff to check `src` and `tests`.
+- [x] Configure MyPy to check `src/camel_up` and `tests`.
+- [x] Keep strictness incremental so refactors remain manageable.
+- [x] Ensure all documented commands work:
 
 ```bash
 uv run python -m pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ pythonpath = [".", "src"]
 [tool.ruff]
 line-length = 88
 target-version = "py310"
-include = ["tests/**/*.py"]
+include = ["src/**/*.py", "tests/**/*.py"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "SIM"]
@@ -48,7 +48,7 @@ indent-style = "space"
 
 [tool.mypy]
 python_version = "3.10"
-files = ["tests"]
+files = ["src/camel_up", "tests"]
 ignore_missing_imports = true
 check_untyped_defs = true
 warn_unused_ignores = true

--- a/tests/engine/test_player_state.py
+++ b/tests/engine/test_player_state.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from dataclasses import replace
 
 import pytest
@@ -105,27 +106,31 @@ def test_spectator_tile_placement_is_derived_from_board_state() -> None:
 
 
 @pytest.mark.parametrize(
-    ("player_kwargs", "message"),
+    ("create_player", "message"),
     [
-        pytest.param({"player_id": -1}, "player_id", id="player-id"),
         pytest.param(
-            {"player_id": 0, "money": -1},
+            lambda: PlayerState(player_id=-1),
+            "player_id",
+            id="player-id",
+        ),
+        pytest.param(
+            lambda: PlayerState(player_id=0, money=-1),
             "money",
             id="money",
         ),
         pytest.param(
-            {"player_id": 0, "pyramid_ticket_count": -1},
+            lambda: PlayerState(player_id=0, pyramid_ticket_count=-1),
             "pyramid_ticket_count",
             id="pyramid-ticket-count",
         ),
     ],
 )
 def test_player_rejects_negative_scalar_resources(
-    player_kwargs: dict[str, int],
+    create_player: Callable[[], PlayerState],
     message: str,
 ) -> None:
     with pytest.raises(ValueError, match=message):
-        PlayerState(**player_kwargs)
+        create_player()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Outcome

Complete Phase 2 by making the standard repository checks cover both production code and tests.

## Changes

- Expand Ruff coverage to src and tests.
- Expand MyPy coverage to src/camel_up and tests while retaining the existing incremental strictness.
- Give the negative PlayerState validation test an explicit callable type so MyPy can verify it without suppressions.
- Mark Phase 2 and the duplicated PR 7 tooling checklist items complete in the foundation plan.

## Non-goals

- No engine or CLI behavior changes.
- No new MyPy strictness settings.
- No package migration or compatibility-shim removal.

## Verification

- uv run python -m pytest (74 passed)
- uv run ruff check .
- uv run ruff format --check .
- uv run python -m mypy
- uv run pre-commit run --all-files