### PR TITLE
feat: add betting state and placement rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,33 @@ the moved unit in the corresponding finish zone and returns a terminal state.
 Spectator-tile movement effects are deferred to a later engine milestone;
 `move_camel` currently rejects a move that would require one.
 
+## Deterministic Betting Transitions
+
+Betting functions transfer tickets and finish cards without mutating the input
+state or applying payouts:
+
+```python
+from camel_up.engine import (
+    CamelId,
+    FinalBetTarget,
+    place_final_bet,
+    take_leg_betting_ticket,
+)
+
+state = take_leg_betting_ticket(state, player_id=0, camel=CamelId.RED)
+state = place_final_bet(
+    state,
+    player_id=1,
+    camel=CamelId.GREEN,
+    target=FinalBetTarget.WINNER,
+)
+```
+
+Shared ticket supplies and ordered winner and loser records are authoritative
+parts of `GameState`. Player-held tickets and unused finish cards remain in
+`PlayerState`. Bet placement does not change money; focused scoring transitions
+will settle those assets in later engine pull requests.
+
 ## Agent Compatibility
 
 `GameState` is immutable, deterministic engine state shared by CLI, search, and

--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ the moved unit in the corresponding finish zone and returns a terminal state.
 Spectator-tile movement effects are deferred to a later engine milestone;
 `move_camel` currently rejects a move that would require one.
 
-## Deterministic Betting Transitions
+## Betting API
 
-Betting functions transfer tickets and finish cards without mutating the input
-state or applying payouts:
+Use the engine betting API to take the top ticket for a racing camel or place a
+finish card on the overall winner or loser record:
 
 ```python
 from camel_up.engine import (
@@ -106,10 +106,9 @@ state = place_final_bet(
 )
 ```
 
-Shared ticket supplies and ordered winner and loser records are authoritative
-parts of `GameState`. Player-held tickets and unused finish cards remain in
-`PlayerState`. Bet placement does not change money; focused scoring transitions
-will settle those assets in later engine pull requests.
+Both operations return a new state and leave their input unchanged. Placing a
+bet does not cost money. Betting settlement is not implemented yet, so these
+operations record player choices without applying payouts.
 
 ## Agent Compatibility
 

--- a/docs/software-foundation-plan.md
+++ b/docs/software-foundation-plan.md
@@ -355,46 +355,161 @@ Review focus:
 - State ownership, canonical ordering, avoiding duplicated facts, and future
   observation encoding.
 
-#### PR 5: `feat: add betting and scoring rules`
+The original betting-and-scoring pull request crossed three independently
+reviewable rule boundaries and was likely to exceed the target size. Implement
+it as PRs 5a through 5c so state ownership stabilizes before either settlement
+path consumes it.
 
-Suggested branch: `feat/betting-scoring-rules`
+Rule contract for this sequence:
 
-Goal: Implement deterministic betting and settlement rules against the stable
-board and player state models.
+- Use the [Camel Up Second Edition rulebook][camel-up-second-edition-rules] as
+  the source of truth for base-game betting and settlement behavior.
+- Implement the Camel Up Second Edition base-game supplies and payouts. Each
+  racing camel begins a leg with betting tickets worth 5, 3, 2, and 2, in that
+  take order.
+- Rank racing camels by track progress and stack level; a racing camel higher
+  in a stack is ahead. A racing camel carried across the backward finish line
+  by a crazy camel is least advanced.
+- A leg ticket pays its printed value for first place, 1 Egyptian Pound for
+  second place, and loses 1 Egyptian Pound otherwise. Each pyramid ticket pays
+  1 Egyptian Pound.
+- Correct final bets, considered in their placement order without incorrect
+  bets consuming a payout position, pay 8, 5, 3, and 2 Egyptian Pounds; every
+  later correct bet pays 1. Each incorrect final bet loses 1.
+- A player's balance never falls below zero.
+
+[camel-up-second-edition-rules]: https://www.lookout-spiele.de/upload/en_camelup.html_CamelUp_PZE30070_Rules_EN_WEB_240305.pdf
+
+#### PR 5a: `feat: add betting state and placement rules`
+
+Status: `Done`
+
+Suggested branch: `feat/betting-rules`
+
+Goal: Represent shared betting state and support deterministic, immutable bet
+placement without implementing settlement.
 
 Tasks:
 
-- [ ] Add canonical shared betting supplies and ordered final-bet records to
-      `GameState` without duplicating player-owned data.
-- [ ] Add `engine.betting` for leg tickets, ordered final bets, ticket
-      availability, and immutable bet placement.
-- [ ] Add `engine.scoring` for leg payouts, final winner and loser payouts, and
-      money updates.
-- [ ] Define leg-owned player asset resets without resetting race-long state.
-- [ ] Keep betting and scoring functions deterministic and free of turn or CLI
-      orchestration.
-- [ ] Add focused tests for ticket exhaustion, bet ordering, payouts, ties where
-      applicable, and leg reset behavior.
+- [x] Add canonical shared leg-ticket supplies and separate ordered final
+      winner and loser bet records to `GameState`.
+- [x] Keep held leg tickets and unused finish cards in `PlayerState`; do not
+      duplicate player-owned data in shared state.
+- [x] Add `engine.betting` functions that take a leg ticket or place a finish
+      card into the requested final-bet record.
+- [x] Validate player identity, racing-camel identity, ticket availability, and
+      finish-card availability while leaving current-turn enforcement to the
+      future action layer.
+- [x] Preserve canonical ordering and hashability across all betting state.
+- [x] Add focused tests for ticket take order and exhaustion, final-bet order,
+      unavailable finish cards, invalid input, and immutable replacement.
 
 Acceptance criteria:
 
-- Betting and scoring transitions preserve immutable state ownership.
-- Ordered final bets and player balances are reproducible from the same state
-  and action history.
-- No CLI, agent, or RL code duplicates payout rules.
+- Every ticket and finish card has one authoritative location in a state.
+- Replaying the same ordered bet placements produces equal, hash-equivalent
+  states and final-bet records.
+- Bet placement contains no scoring, turn advancement, or CLI behavior.
 - All documented checks pass.
 
 Review focus:
 
-- Public versus player-owned state, payout correctness, ordered bets, and leg
-  reset boundaries.
+- Public versus player-owned state, canonical ordering, validation boundaries,
+  and immutable ownership transfer.
+
+Non-goals:
+
+- Camel ranking, payouts, leg resets, legal actions, turns, CLI migration,
+  agents, and RL environments.
+
+#### PR 5b: `feat: add leg ranking and settlement`
+
+Suggested branch: `feat/leg-scoring`
+
+Goal: Score one leg deterministically using the stable board, player, and
+betting state from PR 5a.
+
+Tasks:
+
+- [ ] Add `engine.scoring` racing-camel ordering that excludes crazy camels and
+      handles shared stacks and both finish zones.
+- [ ] Add immutable leg settlement for printed leg-ticket payouts, second-place
+      payouts, losing-ticket penalties, and pyramid-ticket income.
+- [ ] Clear held leg tickets and pyramid-ticket counts and restore the canonical
+      shared leg-ticket supplies after settlement.
+- [ ] Preserve race-long state, including money after settlement, final-bet
+      records, unused finish cards, camel positions, and terminal status.
+- [ ] Leave dice reset, spectator-tile return, leg-number advancement, and
+      current-player advancement to turn orchestration.
+- [ ] Add focused tests for stack-based first and second place, crazy-camel
+      interactions, every payout category, zero-balance flooring, and betting
+      asset reset boundaries.
+
+Acceptance criteria:
+
+- The same board and player holdings always produce the same ranking and
+  balances.
+- Leg settlement resets only betting-related leg assets.
+- The scoring module has no turn, random, or CLI dependencies.
+- All documented checks pass.
+
+Review focus:
+
+- Racing-camel ordering, payout arithmetic, non-negative balances, and the
+  boundary between settlement and full leg orchestration.
+
+Non-goals:
+
+- Final race settlement, dice or tile reset, legal actions, turns, CLI
+  migration, agents, and RL environments.
+
+#### PR 5c: `feat: add final race settlement`
+
+Suggested branch: `feat/final-race-scoring`
+
+Goal: Settle ordered final winner and loser bets for a terminal race using the
+ranking and betting contracts established by PRs 5a and 5b.
+
+Tasks:
+
+- [ ] Determine the winning and losing racing camels from the canonical race
+      order, including same-stack and backward-finish cases.
+- [ ] Score final winner and loser records independently in placement order
+      using the canonical 8, 5, 3, 2, then 1 payout sequence.
+- [ ] Apply incorrect-bet penalties without allowing negative balances.
+- [ ] Record final-settlement completion in `GameState`, reject non-terminal or
+      already-settled input, and preserve immutable bet history for replay and
+      audit.
+- [ ] Add focused tests for ordered correct payouts, incorrect bets, more than
+      four correct bets, same-stack winner and loser selection, backward finish,
+      and deterministic balance updates.
+
+Acceptance criteria:
+
+- Ordered final bets and resulting balances are reproducible from the same
+  terminal state.
+- Winner and loser bets use one shared ranking contract and cannot disagree
+  about race order.
+- Final settlement cannot credit the same terminal state more than once.
+- Final settlement contains no turn or CLI behavior.
+- All documented checks pass.
+
+Review focus:
+
+- Terminal-state validation, ordered payout correctness, winner and loser
+  selection, and non-negative balances.
+
+Non-goals:
+
+- Action generation, turn orchestration, CLI migration, agents, and RL
+  environments.
 
 #### PR 6: `feat: add legal actions and turn progression`
 
 Suggested branch: `feat/legal-actions-turns`
 
-Goal: Compose the completed rules behind one deterministic action and turn
-interface for all future consumers.
+Goal: Compose the completed rules from PR 5c behind one deterministic action
+and turn interface for all future consumers.
 
 Tasks:
 

--- a/src/camel_up/engine/__init__.py
+++ b/src/camel_up/engine/__init__.py
@@ -16,7 +16,7 @@ from camel_up.engine.movement import move_camel
 from camel_up.engine.state import (
     CAMEL_ORDER,
     DIE_ORDER,
-    LEG_BETTING_TICKET_VALUES,
+    LEG_BETTING_TICKET_STACK_VALUES,
     MAX_PLAYERS,
     MIN_PLAYERS,
     RACING_CAMEL_ORDER,
@@ -39,7 +39,7 @@ from camel_up.engine.state import (
 __all__ = [
     "CAMEL_ORDER",
     "DIE_ORDER",
-    "LEG_BETTING_TICKET_VALUES",
+    "LEG_BETTING_TICKET_STACK_VALUES",
     "MAX_PLAYERS",
     "MIN_PLAYERS",
     "RACING_CAMEL_ORDER",

--- a/src/camel_up/engine/__init__.py
+++ b/src/camel_up/engine/__init__.py
@@ -1,5 +1,10 @@
 """Stable public types and queries for the Camel Up engine."""
 
+from camel_up.engine.betting import (
+    available_leg_betting_ticket,
+    place_final_bet,
+    take_leg_betting_ticket,
+)
 from camel_up.engine.dice import (
     DieRoll,
     SetupRoll,
@@ -11,6 +16,7 @@ from camel_up.engine.movement import move_camel
 from camel_up.engine.state import (
     CAMEL_ORDER,
     DIE_ORDER,
+    LEG_BETTING_TICKET_VALUES,
     MAX_PLAYERS,
     MIN_PLAYERS,
     RACING_CAMEL_ORDER,
@@ -18,6 +24,8 @@ from camel_up.engine.state import (
     CamelId,
     CamelPosition,
     DieId,
+    FinalBet,
+    FinalBetTarget,
     GameState,
     LegBettingTicket,
     PlayerState,
@@ -31,6 +39,7 @@ from camel_up.engine.state import (
 __all__ = [
     "CAMEL_ORDER",
     "DIE_ORDER",
+    "LEG_BETTING_TICKET_VALUES",
     "MAX_PLAYERS",
     "MIN_PLAYERS",
     "RACING_CAMEL_ORDER",
@@ -39,17 +48,22 @@ __all__ = [
     "CamelPosition",
     "DieId",
     "DieRoll",
+    "FinalBet",
+    "FinalBetTarget",
     "GameState",
     "LegBettingTicket",
     "PlayerState",
     "SpectatorTile",
     "SetupRoll",
+    "available_leg_betting_ticket",
     "carried_camels",
     "move_camel",
     "position_of",
+    "place_final_bet",
     "reset_leg_dice",
     "roll_die",
     "setup_game",
     "spectator_tile_for_player",
     "stack_at",
+    "take_leg_betting_ticket",
 ]

--- a/src/camel_up/engine/betting.py
+++ b/src/camel_up/engine/betting.py
@@ -62,17 +62,22 @@ def take_leg_betting_ticket(
     """
     _validate_betting_transition(state, player_id)
     camel_index = _racing_camel_index(camel)
-    available_stacks = list(state.available_leg_betting_tickets)
-    ticket_stack = list(available_stacks[camel_index])
-    if not ticket_stack:
+    ticket_stacks = state.available_leg_betting_tickets
+    selected_stack = ticket_stacks[camel_index]
+    if not selected_stack:
         raise ValueError(f"no leg betting ticket is available for {camel.value}")
 
-    ticket = ticket_stack.pop()
-    available_stacks[camel_index] = tuple(ticket_stack)
+    selected_ticket = selected_stack[-1]
+    remaining_stack = selected_stack[:-1]
+    updated_ticket_stacks = (
+        *ticket_stacks[:camel_index],
+        remaining_stack,
+        *ticket_stacks[camel_index + 1 :],
+    )
     player = state.players[player_id]
     held_tickets = tuple(
         sorted(
-            (*player.leg_betting_tickets, ticket),
+            (*player.leg_betting_tickets, selected_ticket),
             key=_leg_betting_ticket_sort_key,
         )
     )
@@ -80,7 +85,7 @@ def take_leg_betting_ticket(
     return replace(
         state,
         players=_replace_player(state.players, updated_player),
-        available_leg_betting_tickets=tuple(available_stacks),
+        available_leg_betting_tickets=updated_ticket_stacks,
     )
 
 

--- a/src/camel_up/engine/betting.py
+++ b/src/camel_up/engine/betting.py
@@ -1,0 +1,140 @@
+"""Deterministic, immutable betting queries and transitions."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from camel_up.engine.state import (
+    RACING_CAMEL_ORDER,
+    CamelId,
+    FinalBet,
+    FinalBetTarget,
+    GameState,
+    LegBettingTicket,
+    PlayerState,
+    _leg_betting_ticket_sort_key,
+)
+
+
+def available_leg_betting_ticket(
+    state: GameState,
+    camel: CamelId,
+) -> LegBettingTicket | None:
+    """Return the next available leg ticket for ``camel``, if one remains."""
+    _validate_racing_camel(camel)
+    return next(
+        (
+            ticket
+            for ticket in state.available_leg_betting_tickets
+            if ticket.camel is camel
+        ),
+        None,
+    )
+
+
+def take_leg_betting_ticket(
+    state: GameState,
+    player_id: int,
+    camel: CamelId,
+) -> GameState:
+    """Transfer the highest available leg ticket to a player.
+
+    This rule transition validates betting-specific availability but does not
+    enforce whose turn it is. The future action layer owns turn legality.
+    """
+    _validate_betting_transition(state, player_id)
+    ticket = available_leg_betting_ticket(state, camel)
+    if ticket is None:
+        raise ValueError("no leg betting ticket is available for that camel")
+
+    ticket_index = state.available_leg_betting_tickets.index(ticket)
+    available_tickets = (
+        state.available_leg_betting_tickets[:ticket_index]
+        + state.available_leg_betting_tickets[ticket_index + 1 :]
+    )
+    player = state.players[player_id]
+    held_tickets = tuple(
+        sorted(
+            (*player.leg_betting_tickets, ticket),
+            key=_leg_betting_ticket_sort_key,
+        )
+    )
+    updated_player = replace(player, leg_betting_tickets=held_tickets)
+    return replace(
+        state,
+        players=_replace_player(state.players, updated_player),
+        available_leg_betting_tickets=available_tickets,
+    )
+
+
+def place_final_bet(
+    state: GameState,
+    player_id: int,
+    camel: CamelId,
+    target: FinalBetTarget,
+) -> GameState:
+    """Move one finish card into the ordered winner or loser bet record.
+
+    Placing a final bet does not cost money. Settlement and turn legality are
+    intentionally deferred to their focused rule layers.
+    """
+    _validate_betting_transition(state, player_id)
+    _validate_racing_camel(camel)
+    if not isinstance(target, FinalBetTarget):
+        raise ValueError("target must be winner or loser")
+
+    player = state.players[player_id]
+    if camel not in player.available_finish_cards:
+        raise ValueError("that finish card is not available")
+
+    available_finish_cards = tuple(
+        card for card in player.available_finish_cards if card is not camel
+    )
+    updated_player = replace(
+        player,
+        available_finish_cards=available_finish_cards,
+    )
+    final_bet = FinalBet(player_id=player_id, camel=camel)
+    winner_bets = state.final_winner_bets
+    loser_bets = state.final_loser_bets
+    if target is FinalBetTarget.WINNER:
+        winner_bets = (*winner_bets, final_bet)
+    else:
+        loser_bets = (*loser_bets, final_bet)
+
+    return replace(
+        state,
+        players=_replace_player(state.players, updated_player),
+        final_winner_bets=winner_bets,
+        final_loser_bets=loser_bets,
+    )
+
+
+def _validate_betting_transition(state: GameState, player_id: int) -> None:
+    """Reject states and player identities that cannot place a bet."""
+    if not 0 <= player_id < len(state.players):
+        raise ValueError("player_id must identify a player in players")
+    if not all(position.is_placed for position in state.board.camel_positions):
+        raise ValueError("initial setup must be completed before betting")
+    if state.terminal:
+        raise ValueError("cannot place a bet after the game has ended")
+    if len(state.remaining_dice) <= 1:
+        raise ValueError("the leg is complete; settle it before betting")
+
+
+def _validate_racing_camel(camel: CamelId) -> None:
+    """Reject crazy camels, which are never valid betting subjects."""
+    if camel not in RACING_CAMEL_ORDER:
+        raise ValueError("bets must predict a racing camel")
+
+
+def _replace_player(
+    players: tuple[PlayerState, ...],
+    updated_player: PlayerState,
+) -> tuple[PlayerState, ...]:
+    """Replace one canonically indexed player without mutating the tuple."""
+    return (
+        players[: updated_player.player_id]
+        + (updated_player,)
+        + players[updated_player.player_id + 1 :]
+    )

--- a/src/camel_up/engine/betting.py
+++ b/src/camel_up/engine/betting.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import replace
 
 from camel_up.engine.state import (
-    _CAMEL_INDEX,
     RACING_CAMEL_ORDER,
     CamelId,
     FinalBet,
@@ -13,7 +12,7 @@ from camel_up.engine.state import (
     GameState,
     LegBettingTicket,
     PlayerState,
-    _leg_betting_ticket_sort_key,
+    canonical_leg_betting_tickets,
 )
 
 
@@ -75,11 +74,8 @@ def take_leg_betting_ticket(
         *ticket_stacks[camel_index + 1 :],
     )
     player = state.players[player_id]
-    held_tickets = tuple(
-        sorted(
-            (*player.leg_betting_tickets, selected_ticket),
-            key=_leg_betting_ticket_sort_key,
-        )
+    held_tickets = canonical_leg_betting_tickets(
+        (*player.leg_betting_tickets, selected_ticket)
     )
     updated_player = replace(player, leg_betting_tickets=held_tickets)
     return replace(
@@ -114,7 +110,7 @@ def place_final_bet(
             player has already used that camel's finish card.
     """
     _validate_betting_transition(state, player_id)
-    _racing_camel_index(camel)
+    _validate_racing_camel(camel)
     if not isinstance(target, FinalBetTarget):
         raise ValueError(f"target must be winner or loser, got {target!r}")
 
@@ -161,9 +157,14 @@ def _validate_betting_transition(state: GameState, player_id: int) -> None:
 
 def _racing_camel_index(camel: CamelId) -> int:
     """Return a racing camel's stable supply index."""
+    _validate_racing_camel(camel)
+    return RACING_CAMEL_ORDER.index(camel)
+
+
+def _validate_racing_camel(camel: CamelId) -> None:
+    """Reject camel identities that cannot receive bets."""
     if not isinstance(camel, CamelId) or camel not in RACING_CAMEL_ORDER:
         raise ValueError(f"bets must predict a racing camel, got {camel!r}")
-    return _CAMEL_INDEX[camel]
 
 
 def _replace_player(

--- a/src/camel_up/engine/betting.py
+++ b/src/camel_up/engine/betting.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import replace
 
 from camel_up.engine.state import (
+    _CAMEL_INDEX,
     RACING_CAMEL_ORDER,
     CamelId,
     FinalBet,
@@ -20,16 +21,21 @@ def available_leg_betting_ticket(
     state: GameState,
     camel: CamelId,
 ) -> LegBettingTicket | None:
-    """Return the next available leg ticket for ``camel``, if one remains."""
-    _validate_racing_camel(camel)
-    return next(
-        (
-            ticket
-            for ticket in state.available_leg_betting_tickets
-            if ticket.camel is camel
-        ),
-        None,
-    )
+    """Return the top available leg ticket for a racing camel.
+
+    Args:
+        state: Current immutable game state.
+        camel: Racing camel whose ticket stack should be queried.
+
+    Returns:
+        The top ticket, or ``None`` when that camel's stack is empty.
+
+    Raises:
+        ValueError: If ``camel`` identifies a crazy camel.
+    """
+    camel_index = _racing_camel_index(camel)
+    ticket_stack = state.available_leg_betting_tickets[camel_index]
+    return ticket_stack[-1] if ticket_stack else None
 
 
 def take_leg_betting_ticket(
@@ -41,17 +47,28 @@ def take_leg_betting_ticket(
 
     This rule transition validates betting-specific availability but does not
     enforce whose turn it is. The future action layer owns turn legality.
+
+    Args:
+        state: Active game state before the bet.
+        player_id: Stable identity of the player taking the ticket.
+        camel: Racing camel backed by the requested ticket.
+
+    Returns:
+        A replacement state with the top ticket transferred to the player.
+
+    Raises:
+        ValueError: If betting is unavailable, the player or camel is invalid,
+            or that camel's ticket stack is empty.
     """
     _validate_betting_transition(state, player_id)
-    ticket = available_leg_betting_ticket(state, camel)
-    if ticket is None:
-        raise ValueError("no leg betting ticket is available for that camel")
+    camel_index = _racing_camel_index(camel)
+    available_stacks = list(state.available_leg_betting_tickets)
+    ticket_stack = list(available_stacks[camel_index])
+    if not ticket_stack:
+        raise ValueError(f"no leg betting ticket is available for {camel.value}")
 
-    ticket_index = state.available_leg_betting_tickets.index(ticket)
-    available_tickets = (
-        state.available_leg_betting_tickets[:ticket_index]
-        + state.available_leg_betting_tickets[ticket_index + 1 :]
-    )
+    ticket = ticket_stack.pop()
+    available_stacks[camel_index] = tuple(ticket_stack)
     player = state.players[player_id]
     held_tickets = tuple(
         sorted(
@@ -63,7 +80,7 @@ def take_leg_betting_ticket(
     return replace(
         state,
         players=_replace_player(state.players, updated_player),
-        available_leg_betting_tickets=available_tickets,
+        available_leg_betting_tickets=tuple(available_stacks),
     )
 
 
@@ -77,15 +94,30 @@ def place_final_bet(
 
     Placing a final bet does not cost money. Settlement and turn legality are
     intentionally deferred to their focused rule layers.
+
+    Args:
+        state: Active game state before the bet.
+        player_id: Stable identity of the player placing the finish card.
+        camel: Racing camel predicted to finish first or last.
+        target: Ordered winner or loser record that receives the card.
+
+    Returns:
+        A replacement state with the card moved into the selected record.
+
+    Raises:
+        ValueError: If betting is unavailable, an argument is invalid, or the
+            player has already used that camel's finish card.
     """
     _validate_betting_transition(state, player_id)
-    _validate_racing_camel(camel)
+    _racing_camel_index(camel)
     if not isinstance(target, FinalBetTarget):
-        raise ValueError("target must be winner or loser")
+        raise ValueError(f"target must be winner or loser, got {target!r}")
 
     player = state.players[player_id]
     if camel not in player.available_finish_cards:
-        raise ValueError("that finish card is not available")
+        raise ValueError(
+            f"{camel.value} finish card is not available for player {player_id}"
+        )
 
     available_finish_cards = tuple(
         card for card in player.available_finish_cards if card is not camel
@@ -113,7 +145,7 @@ def place_final_bet(
 def _validate_betting_transition(state: GameState, player_id: int) -> None:
     """Reject states and player identities that cannot place a bet."""
     if not 0 <= player_id < len(state.players):
-        raise ValueError("player_id must identify a player in players")
+        raise ValueError(f"player_id {player_id} must identify a player in players")
     if not all(position.is_placed for position in state.board.camel_positions):
         raise ValueError("initial setup must be completed before betting")
     if state.terminal:
@@ -122,10 +154,11 @@ def _validate_betting_transition(state: GameState, player_id: int) -> None:
         raise ValueError("the leg is complete; settle it before betting")
 
 
-def _validate_racing_camel(camel: CamelId) -> None:
-    """Reject crazy camels, which are never valid betting subjects."""
-    if camel not in RACING_CAMEL_ORDER:
-        raise ValueError("bets must predict a racing camel")
+def _racing_camel_index(camel: CamelId) -> int:
+    """Return a racing camel's stable supply index."""
+    if not isinstance(camel, CamelId) or camel not in RACING_CAMEL_ORDER:
+        raise ValueError(f"bets must predict a racing camel, got {camel!r}")
+    return _CAMEL_INDEX[camel]
 
 
 def _replace_player(

--- a/src/camel_up/engine/state.py
+++ b/src/camel_up/engine/state.py
@@ -31,6 +31,13 @@ class DieId(str, Enum):
     GREY = "grey"
 
 
+class FinalBetTarget(str, Enum):
+    """The final betting record a finish card predicts."""
+
+    WINNER = "winner"
+    LOSER = "loser"
+
+
 # Stable identity/serialization order; this is unrelated to current race ranking.
 RACING_CAMEL_ORDER: Final = (
     CamelId.RED,
@@ -43,6 +50,7 @@ CAMEL_ORDER: Final = (*RACING_CAMEL_ORDER, CamelId.WHITE, CamelId.BLACK)
 DIE_ORDER: Final = tuple(DieId)
 MIN_PLAYERS: Final = 3
 MAX_PLAYERS: Final = 8
+LEG_BETTING_TICKET_VALUES: Final = (5, 3, 2, 2)
 _CAMEL_INDEX: Final = MappingProxyType(
     {camel: index for index, camel in enumerate(CAMEL_ORDER)}
 )
@@ -114,8 +122,27 @@ class LegBettingTicket:
         """Require a printed ticket from the racing-camel supply."""
         if self.camel not in RACING_CAMEL_ORDER:
             raise ValueError("leg betting tickets must show a racing camel")
-        if self.value not in (2, 3, 5):
+        if self.value not in LEG_BETTING_TICKET_VALUES:
             raise ValueError("leg betting ticket value must be 2, 3, or 5")
+
+
+@dataclass(frozen=True, slots=True)
+class FinalBet:
+    """One finish card placed into an ordered final betting record.
+
+    The containing winner or loser tuple determines what the card predicts, so
+    the target is not duplicated on each record.
+    """
+
+    player_id: int
+    camel: CamelId
+
+    def __post_init__(self) -> None:
+        """Require a possible player identity and racing-camel prediction."""
+        if self.player_id < 0:
+            raise ValueError("player_id must be non-negative")
+        if self.camel not in RACING_CAMEL_ORDER:
+            raise ValueError("final bets must predict a racing camel")
 
 
 def _leg_betting_ticket_sort_key(
@@ -123,6 +150,13 @@ def _leg_betting_ticket_sort_key(
 ) -> tuple[int, int]:
     """Order by ``RACING_CAMEL_ORDER``, then by descending ticket value."""
     return _CAMEL_INDEX[ticket.camel], -ticket.value
+
+
+INITIAL_LEG_BETTING_TICKETS: Final = tuple(
+    LegBettingTicket(camel=camel, value=value)
+    for camel in RACING_CAMEL_ORDER
+    for value in LEG_BETTING_TICKET_VALUES
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -285,6 +319,11 @@ class GameState:
     It contains complete game truth; agents must consume a future
     player-relative observation rather than this state directly when the rules
     require hidden information.
+
+    Shared ticket supplies and ordered final betting records live here, while
+    held tickets and unused finish cards live on their owning
+    :class:`PlayerState`. Construction validates that those locations conserve
+    every betting asset.
     """
 
     board: BoardState
@@ -293,6 +332,11 @@ class GameState:
     current_player: int = 0
     leg_number: int = 1
     terminal: bool = False
+    available_leg_betting_tickets: tuple[LegBettingTicket, ...] = (
+        INITIAL_LEG_BETTING_TICKETS
+    )
+    final_winner_bets: tuple[FinalBet, ...] = ()
+    final_loser_bets: tuple[FinalBet, ...] = ()
 
     @classmethod
     def pre_setup(
@@ -321,6 +365,7 @@ class GameState:
             tile.player_id >= len(self.players) for tile in self.board.spectator_tiles
         ):
             raise ValueError("spectator tiles must belong to a player in players")
+        self._validate_betting_assets()
         if len(self.remaining_dice) != len(set(self.remaining_dice)):
             raise ValueError("remaining_dice cannot contain duplicates")
         expected_order = tuple(die for die in DIE_ORDER if die in self.remaining_dice)
@@ -333,6 +378,59 @@ class GameState:
             for position in self.board.camel_positions
         ):
             raise ValueError("a camel in a finish zone requires a terminal game")
+
+    def _validate_betting_assets(self) -> None:
+        """Require canonical supplies and conserve every betting asset."""
+        expected_available_order = tuple(
+            sorted(
+                self.available_leg_betting_tickets,
+                key=_leg_betting_ticket_sort_key,
+            )
+        )
+        if self.available_leg_betting_tickets != expected_available_order:
+            raise ValueError("available_leg_betting_tickets must use canonical order")
+
+        held_tickets = tuple(
+            ticket for player in self.players for ticket in player.leg_betting_tickets
+        )
+        all_leg_tickets = tuple(
+            sorted(
+                (*self.available_leg_betting_tickets, *held_tickets),
+                key=_leg_betting_ticket_sort_key,
+            )
+        )
+        if all_leg_tickets != INITIAL_LEG_BETTING_TICKETS:
+            raise ValueError(
+                "available and held leg betting tickets must conserve the "
+                "initial supply"
+            )
+
+        all_finish_cards = [
+            (player.player_id, camel)
+            for player in self.players
+            for camel in player.available_finish_cards
+        ]
+        for bet in (*self.final_winner_bets, *self.final_loser_bets):
+            if bet.player_id >= len(self.players):
+                raise ValueError("final bets must belong to a player in players")
+            all_finish_cards.append((bet.player_id, bet.camel))
+
+        expected_finish_cards = tuple(
+            (player.player_id, camel)
+            for player in self.players
+            for camel in RACING_CAMEL_ORDER
+        )
+        ordered_finish_cards = tuple(
+            sorted(
+                all_finish_cards,
+                key=lambda card: (card[0], _CAMEL_INDEX[card[1]]),
+            )
+        )
+        if ordered_finish_cards != expected_finish_cards:
+            raise ValueError(
+                "available finish cards and final bets must conserve one card "
+                "per player and racing camel"
+            )
 
 
 def position_of(board: BoardState, camel: CamelId) -> CamelPosition:

--- a/src/camel_up/engine/state.py
+++ b/src/camel_up/engine/state.py
@@ -32,7 +32,7 @@ class DieId(str, Enum):
 
 
 class FinalBetTarget(str, Enum):
-    """The final betting record a finish card predicts."""
+    """The final betting record that receives a finish card."""
 
     WINNER = "winner"
     LOSER = "loser"
@@ -50,7 +50,8 @@ CAMEL_ORDER: Final = (*RACING_CAMEL_ORDER, CamelId.WHITE, CamelId.BLACK)
 DIE_ORDER: Final = tuple(DieId)
 MIN_PLAYERS: Final = 3
 MAX_PLAYERS: Final = 8
-LEG_BETTING_TICKET_VALUES: Final = (5, 3, 2, 2)
+# Each stack is stored from bottom to top so its available ticket is last.
+LEG_BETTING_TICKET_STACK_VALUES: Final = (2, 2, 3, 5)
 _CAMEL_INDEX: Final = MappingProxyType(
     {camel: index for index, camel in enumerate(CAMEL_ORDER)}
 )
@@ -122,7 +123,7 @@ class LegBettingTicket:
         """Require a printed ticket from the racing-camel supply."""
         if self.camel not in RACING_CAMEL_ORDER:
             raise ValueError("leg betting tickets must show a racing camel")
-        if self.value not in LEG_BETTING_TICKET_VALUES:
+        if self.value not in LEG_BETTING_TICKET_STACK_VALUES:
             raise ValueError("leg betting ticket value must be 2, 3, or 5")
 
 
@@ -132,6 +133,14 @@ class FinalBet:
 
     The containing winner or loser tuple determines what the card predicts, so
     the target is not duplicated on each record.
+
+    The record can reject negative player IDs independently. The containing
+    :class:`GameState` validates the upper bound against its actual player
+    roster.
+
+    Attributes:
+        player_id: Stable identity of the player who placed the finish card.
+        camel: Racing camel predicted to finish first or last.
     """
 
     player_id: int
@@ -152,10 +161,18 @@ def _leg_betting_ticket_sort_key(
     return _CAMEL_INDEX[ticket.camel], -ticket.value
 
 
-INITIAL_LEG_BETTING_TICKETS: Final = tuple(
-    LegBettingTicket(camel=camel, value=value)
+INITIAL_LEG_BETTING_TICKET_STACKS: Final = tuple(
+    tuple(
+        LegBettingTicket(camel=camel, value=value)
+        for value in LEG_BETTING_TICKET_STACK_VALUES
+    )
     for camel in RACING_CAMEL_ORDER
-    for value in LEG_BETTING_TICKET_VALUES
+)
+_ALL_LEG_BETTING_TICKETS: Final = tuple(
+    sorted(
+        (ticket for stack in INITIAL_LEG_BETTING_TICKET_STACKS for ticket in stack),
+        key=_leg_betting_ticket_sort_key,
+    )
 )
 
 
@@ -332,8 +349,8 @@ class GameState:
     current_player: int = 0
     leg_number: int = 1
     terminal: bool = False
-    available_leg_betting_tickets: tuple[LegBettingTicket, ...] = (
-        INITIAL_LEG_BETTING_TICKETS
+    available_leg_betting_tickets: tuple[tuple[LegBettingTicket, ...], ...] = (
+        INITIAL_LEG_BETTING_TICKET_STACKS
     )
     final_winner_bets: tuple[FinalBet, ...] = ()
     final_loser_bets: tuple[FinalBet, ...] = ()
@@ -365,7 +382,8 @@ class GameState:
             tile.player_id >= len(self.players) for tile in self.board.spectator_tiles
         ):
             raise ValueError("spectator tiles must belong to a player in players")
-        self._validate_betting_assets()
+        self._validate_leg_betting_assets()
+        self._validate_finish_card_assets()
         if len(self.remaining_dice) != len(set(self.remaining_dice)):
             raise ValueError("remaining_dice cannot contain duplicates")
         expected_order = tuple(die for die in DIE_ORDER if die in self.remaining_dice)
@@ -379,32 +397,41 @@ class GameState:
         ):
             raise ValueError("a camel in a finish zone requires a terminal game")
 
-    def _validate_betting_assets(self) -> None:
-        """Require canonical supplies and conserve every betting asset."""
-        expected_available_order = tuple(
-            sorted(
-                self.available_leg_betting_tickets,
-                key=_leg_betting_ticket_sort_key,
-            )
-        )
-        if self.available_leg_betting_tickets != expected_available_order:
+    def _validate_leg_betting_assets(self) -> None:
+        """Require canonical stacks and conserve every leg betting ticket."""
+        if len(self.available_leg_betting_tickets) != len(RACING_CAMEL_ORDER):
             raise ValueError("available_leg_betting_tickets must use canonical order")
+
+        for available_stack, initial_stack in zip(
+            self.available_leg_betting_tickets,
+            INITIAL_LEG_BETTING_TICKET_STACKS,
+            strict=True,
+        ):
+            if available_stack != initial_stack[: len(available_stack)]:
+                raise ValueError(
+                    "available_leg_betting_tickets must use canonical stacks"
+                )
 
         held_tickets = tuple(
             ticket for player in self.players for ticket in player.leg_betting_tickets
         )
+        available_tickets = tuple(
+            ticket for stack in self.available_leg_betting_tickets for ticket in stack
+        )
         all_leg_tickets = tuple(
             sorted(
-                (*self.available_leg_betting_tickets, *held_tickets),
+                (*available_tickets, *held_tickets),
                 key=_leg_betting_ticket_sort_key,
             )
         )
-        if all_leg_tickets != INITIAL_LEG_BETTING_TICKETS:
+        if all_leg_tickets != _ALL_LEG_BETTING_TICKETS:
             raise ValueError(
                 "available and held leg betting tickets must conserve the "
                 "initial supply"
             )
 
+    def _validate_finish_card_assets(self) -> None:
+        """Conserve finish cards across players and final betting records."""
         all_finish_cards = [
             (player.player_id, camel)
             for player in self.players

--- a/src/camel_up/engine/state.py
+++ b/src/camel_up/engine/state.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum
 from types import MappingProxyType
@@ -161,6 +162,19 @@ def _leg_betting_ticket_sort_key(
     return _CAMEL_INDEX[ticket.camel], -ticket.value
 
 
+def canonical_leg_betting_tickets(
+    tickets: Iterable[LegBettingTicket],
+) -> tuple[LegBettingTicket, ...]:
+    """Return leg tickets in the canonical player-holdings order."""
+    return tuple(sorted(tickets, key=_leg_betting_ticket_sort_key))
+
+
+def _finish_card_sort_key(card: tuple[int, CamelId]) -> tuple[int, int]:
+    """Order a finish card by player identity, then racing camel identity."""
+    player_id, camel = card
+    return player_id, _CAMEL_INDEX[camel]
+
+
 INITIAL_LEG_BETTING_TICKET_STACKS: Final = tuple(
     tuple(
         LegBettingTicket(camel=camel, value=value)
@@ -168,11 +182,8 @@ INITIAL_LEG_BETTING_TICKET_STACKS: Final = tuple(
     )
     for camel in RACING_CAMEL_ORDER
 )
-_ALL_LEG_BETTING_TICKETS: Final = tuple(
-    sorted(
-        (ticket for stack in INITIAL_LEG_BETTING_TICKET_STACKS for ticket in stack),
-        key=_leg_betting_ticket_sort_key,
-    )
+_ALL_LEG_BETTING_TICKETS: Final = canonical_leg_betting_tickets(
+    ticket for stack in INITIAL_LEG_BETTING_TICKET_STACKS for ticket in stack
 )
 
 
@@ -215,12 +226,7 @@ class PlayerState:
         if self.pyramid_ticket_count < 0:
             raise ValueError("pyramid_ticket_count must be non-negative")
 
-        expected_tickets = tuple(
-            sorted(
-                self.leg_betting_tickets,
-                key=_leg_betting_ticket_sort_key,
-            )
-        )
+        expected_tickets = canonical_leg_betting_tickets(self.leg_betting_tickets)
         if self.leg_betting_tickets != expected_tickets:
             raise ValueError("leg_betting_tickets must use canonical order")
 
@@ -418,11 +424,8 @@ class GameState:
         available_tickets = tuple(
             ticket for stack in self.available_leg_betting_tickets for ticket in stack
         )
-        all_leg_tickets = tuple(
-            sorted(
-                (*available_tickets, *held_tickets),
-                key=_leg_betting_ticket_sort_key,
-            )
+        all_leg_tickets = canonical_leg_betting_tickets(
+            (*available_tickets, *held_tickets)
         )
         if all_leg_tickets != _ALL_LEG_BETTING_TICKETS:
             raise ValueError(
@@ -450,7 +453,7 @@ class GameState:
         ordered_finish_cards = tuple(
             sorted(
                 all_finish_cards,
-                key=lambda card: (card[0], _CAMEL_INDEX[card[1]]),
+                key=_finish_card_sort_key,
             )
         )
         if ordered_finish_cards != expected_finish_cards:

--- a/tests/engine/test_betting.py
+++ b/tests/engine/test_betting.py
@@ -5,7 +5,7 @@ from typing import cast
 import pytest
 
 from camel_up.engine import (
-    LEG_BETTING_TICKET_VALUES,
+    LEG_BETTING_TICKET_STACK_VALUES,
     MIN_PLAYERS,
     RACING_CAMEL_ORDER,
     CamelId,
@@ -30,21 +30,33 @@ def _tickets_for_camel(
     state: GameState,
     camel: CamelId,
 ) -> tuple[LegBettingTicket, ...]:
-    return tuple(
-        ticket
-        for ticket in state.available_leg_betting_tickets
-        if ticket.camel is camel
-    )
+    return state.available_leg_betting_tickets[RACING_CAMEL_ORDER.index(camel)]
 
 
-def test_pre_setup_contains_the_canonical_shared_ticket_supply() -> None:
+def test_pre_setup_contains_canonical_bottom_to_top_ticket_stacks() -> None:
     state = GameState.pre_setup()
 
     for camel in RACING_CAMEL_ORDER:
         tickets = _tickets_for_camel(state, camel)
 
-        assert tuple(ticket.value for ticket in tickets) == (LEG_BETTING_TICKET_VALUES)
-        assert available_leg_betting_ticket(state, camel) == tickets[0]
+        assert tuple(ticket.value for ticket in tickets) == (
+            LEG_BETTING_TICKET_STACK_VALUES
+        )
+        assert all(ticket.camel is camel for ticket in tickets)
+
+
+def test_available_leg_betting_ticket_returns_top_ticket_or_none() -> None:
+    state = _setup_state()
+
+    assert available_leg_betting_ticket(state, CamelId.GREEN) == LegBettingTicket(
+        camel=CamelId.GREEN,
+        value=5,
+    )
+
+    for _ in LEG_BETTING_TICKET_STACK_VALUES:
+        state = take_leg_betting_ticket(state, 0, CamelId.GREEN)
+
+    assert available_leg_betting_ticket(state, CamelId.GREEN) is None
 
 
 def test_taking_leg_ticket_transfers_the_highest_value_immutably() -> None:
@@ -57,7 +69,7 @@ def test_taking_leg_ticket_transfers_the_highest_value_immutably() -> None:
     )
     assert tuple(
         ticket.value for ticket in _tickets_for_camel(updated, CamelId.GREEN)
-    ) == (3, 2, 2)
+    ) == (2, 2, 3)
     assert available_leg_betting_ticket(updated, CamelId.GREEN) == LegBettingTicket(
         camel=CamelId.GREEN,
         value=3,
@@ -65,7 +77,7 @@ def test_taking_leg_ticket_transfers_the_highest_value_immutably() -> None:
     assert state.players[1].leg_betting_tickets == ()
     assert (
         tuple(ticket.value for ticket in _tickets_for_camel(state, CamelId.GREEN))
-        == LEG_BETTING_TICKET_VALUES
+        == LEG_BETTING_TICKET_STACK_VALUES
     )
     assert updated.players[1].money == state.players[1].money
 
@@ -74,7 +86,8 @@ def test_leg_tickets_follow_take_order_and_then_exhaust() -> None:
     state = _setup_state()
 
     taken_values: list[int] = []
-    for draw_index, _ in enumerate(LEG_BETTING_TICKET_VALUES):
+    expected_take_order = tuple(reversed(LEG_BETTING_TICKET_STACK_VALUES))
+    for draw_index, _ in enumerate(expected_take_order):
         ticket = available_leg_betting_ticket(state, CamelId.RED)
         assert ticket is not None
         taken_values.append(ticket.value)
@@ -84,7 +97,7 @@ def test_leg_tickets_follow_take_order_and_then_exhaust() -> None:
             camel=CamelId.RED,
         )
 
-    assert taken_values == list(LEG_BETTING_TICKET_VALUES)
+    assert taken_values == list(expected_take_order)
     assert available_leg_betting_ticket(state, CamelId.RED) is None
     with pytest.raises(ValueError, match="no leg betting ticket"):
         take_leg_betting_ticket(state, player_id=0, camel=CamelId.RED)
@@ -212,32 +225,33 @@ def test_betting_rejects_inactive_game_states(
 
 def test_game_rejects_noncanonical_available_ticket_order() -> None:
     state = GameState.pre_setup()
-    tickets = state.available_leg_betting_tickets
+    stacks = state.available_leg_betting_tickets
+    red_stack = stacks[0]
+    noncanonical_red_stack = (*red_stack[:2], red_stack[3], red_stack[2])
 
-    with pytest.raises(ValueError, match="canonical order"):
+    with pytest.raises(ValueError, match="canonical stacks"):
         replace(
             state,
-            available_leg_betting_tickets=(tickets[1], tickets[0], *tickets[2:]),
+            available_leg_betting_tickets=(noncanonical_red_stack, *stacks[1:]),
         )
 
 
 def test_game_rejects_missing_or_duplicated_leg_tickets() -> None:
     state = GameState.pre_setup()
+    stacks = state.available_leg_betting_tickets
 
     with pytest.raises(ValueError, match="conserve the initial supply"):
         replace(
             state,
-            available_leg_betting_tickets=state.available_leg_betting_tickets[1:],
+            available_leg_betting_tickets=(stacks[0][:-1], *stacks[1:]),
         )
 
+    player = replace(
+        state.players[0],
+        leg_betting_tickets=(LegBettingTicket(camel=CamelId.RED, value=5),),
+    )
     with pytest.raises(ValueError, match="conserve the initial supply"):
-        replace(
-            state,
-            available_leg_betting_tickets=(
-                state.available_leg_betting_tickets[0],
-                *state.available_leg_betting_tickets,
-            ),
-        )
+        replace(state, players=(player, *state.players[1:]))
 
 
 def test_game_rejects_finish_card_missing_from_both_locations() -> None:
@@ -251,7 +265,7 @@ def test_game_rejects_finish_card_missing_from_both_locations() -> None:
         replace(state, players=(player, *state.players[1:]))
 
 
-def test_game_rejects_duplicated_or_unknown_final_bets() -> None:
+def test_game_rejects_finish_card_in_both_final_records() -> None:
     state = place_final_bet(
         _setup_state(),
         player_id=0,
@@ -262,6 +276,10 @@ def test_game_rejects_duplicated_or_unknown_final_bets() -> None:
 
     with pytest.raises(ValueError, match="conserve one card"):
         replace(state, final_loser_bets=(bet,))
+
+
+def test_game_rejects_final_bet_for_player_outside_roster() -> None:
+    state = _setup_state()
 
     with pytest.raises(ValueError, match="belong to a player"):
         replace(

--- a/tests/engine/test_betting.py
+++ b/tests/engine/test_betting.py
@@ -1,0 +1,289 @@
+import random
+from dataclasses import replace
+from typing import cast
+
+import pytest
+
+from camel_up.engine import (
+    LEG_BETTING_TICKET_VALUES,
+    MIN_PLAYERS,
+    RACING_CAMEL_ORDER,
+    CamelId,
+    DieId,
+    FinalBet,
+    FinalBetTarget,
+    GameState,
+    LegBettingTicket,
+    available_leg_betting_ticket,
+    place_final_bet,
+    setup_game,
+    take_leg_betting_ticket,
+)
+
+
+def _setup_state(seed: int = 41) -> GameState:
+    state, _ = setup_game(GameState.pre_setup(), random.Random(seed))
+    return state
+
+
+def _tickets_for_camel(
+    state: GameState,
+    camel: CamelId,
+) -> tuple[LegBettingTicket, ...]:
+    return tuple(
+        ticket
+        for ticket in state.available_leg_betting_tickets
+        if ticket.camel is camel
+    )
+
+
+def test_pre_setup_contains_the_canonical_shared_ticket_supply() -> None:
+    state = GameState.pre_setup()
+
+    for camel in RACING_CAMEL_ORDER:
+        tickets = _tickets_for_camel(state, camel)
+
+        assert tuple(ticket.value for ticket in tickets) == (LEG_BETTING_TICKET_VALUES)
+        assert available_leg_betting_ticket(state, camel) == tickets[0]
+
+
+def test_taking_leg_ticket_transfers_the_highest_value_immutably() -> None:
+    state = _setup_state()
+
+    updated = take_leg_betting_ticket(state, player_id=1, camel=CamelId.GREEN)
+
+    assert updated.players[1].leg_betting_tickets == (
+        LegBettingTicket(camel=CamelId.GREEN, value=5),
+    )
+    assert tuple(
+        ticket.value for ticket in _tickets_for_camel(updated, CamelId.GREEN)
+    ) == (3, 2, 2)
+    assert available_leg_betting_ticket(updated, CamelId.GREEN) == LegBettingTicket(
+        camel=CamelId.GREEN,
+        value=3,
+    )
+    assert state.players[1].leg_betting_tickets == ()
+    assert (
+        tuple(ticket.value for ticket in _tickets_for_camel(state, CamelId.GREEN))
+        == LEG_BETTING_TICKET_VALUES
+    )
+    assert updated.players[1].money == state.players[1].money
+
+
+def test_leg_tickets_follow_take_order_and_then_exhaust() -> None:
+    state = _setup_state()
+
+    taken_values: list[int] = []
+    for draw_index, _ in enumerate(LEG_BETTING_TICKET_VALUES):
+        ticket = available_leg_betting_ticket(state, CamelId.RED)
+        assert ticket is not None
+        taken_values.append(ticket.value)
+        state = take_leg_betting_ticket(
+            state,
+            player_id=draw_index % MIN_PLAYERS,
+            camel=CamelId.RED,
+        )
+
+    assert taken_values == list(LEG_BETTING_TICKET_VALUES)
+    assert available_leg_betting_ticket(state, CamelId.RED) is None
+    with pytest.raises(ValueError, match="no leg betting ticket"):
+        take_leg_betting_ticket(state, player_id=0, camel=CamelId.RED)
+
+
+def test_taking_different_colors_keeps_player_tickets_canonical() -> None:
+    state = _setup_state()
+
+    state = take_leg_betting_ticket(state, player_id=2, camel=CamelId.PURPLE)
+    state = take_leg_betting_ticket(state, player_id=2, camel=CamelId.RED)
+
+    assert state.players[2].leg_betting_tickets == (
+        LegBettingTicket(camel=CamelId.RED, value=5),
+        LegBettingTicket(camel=CamelId.PURPLE, value=5),
+    )
+
+
+def test_final_bets_remove_cards_and_keep_independent_ordered_records() -> None:
+    state = _setup_state()
+
+    state = place_final_bet(
+        state,
+        player_id=1,
+        camel=CamelId.GREEN,
+        target=FinalBetTarget.WINNER,
+    )
+    state = place_final_bet(
+        state,
+        player_id=0,
+        camel=CamelId.RED,
+        target=FinalBetTarget.LOSER,
+    )
+    state = place_final_bet(
+        state,
+        player_id=2,
+        camel=CamelId.BLUE,
+        target=FinalBetTarget.WINNER,
+    )
+
+    assert state.final_winner_bets == (
+        FinalBet(player_id=1, camel=CamelId.GREEN),
+        FinalBet(player_id=2, camel=CamelId.BLUE),
+    )
+    assert state.final_loser_bets == (FinalBet(player_id=0, camel=CamelId.RED),)
+    assert CamelId.GREEN not in state.players[1].available_finish_cards
+    assert CamelId.RED not in state.players[0].available_finish_cards
+    assert CamelId.BLUE not in state.players[2].available_finish_cards
+    assert all(player.money == 3 for player in state.players)
+
+
+def test_finish_card_cannot_be_used_in_both_final_records() -> None:
+    state = place_final_bet(
+        _setup_state(),
+        player_id=0,
+        camel=CamelId.YELLOW,
+        target=FinalBetTarget.WINNER,
+    )
+
+    with pytest.raises(ValueError, match="finish card is not available"):
+        place_final_bet(
+            state,
+            player_id=0,
+            camel=CamelId.YELLOW,
+            target=FinalBetTarget.LOSER,
+        )
+
+
+@pytest.mark.parametrize("player_id", [-1, MIN_PLAYERS])
+@pytest.mark.parametrize("bet_kind", ["leg", "final"])
+def test_betting_rejects_unknown_player(player_id: int, bet_kind: str) -> None:
+    state = _setup_state()
+
+    with pytest.raises(ValueError, match="identify a player"):
+        if bet_kind == "leg":
+            take_leg_betting_ticket(state, player_id, CamelId.RED)
+        else:
+            place_final_bet(
+                state,
+                player_id,
+                CamelId.RED,
+                FinalBetTarget.WINNER,
+            )
+
+
+def test_betting_queries_and_transitions_reject_crazy_camels() -> None:
+    state = _setup_state()
+
+    with pytest.raises(ValueError, match="racing camel"):
+        available_leg_betting_ticket(state, CamelId.WHITE)
+    with pytest.raises(ValueError, match="racing camel"):
+        take_leg_betting_ticket(state, 0, CamelId.BLACK)
+    with pytest.raises(ValueError, match="racing camel"):
+        place_final_bet(state, 0, CamelId.WHITE, FinalBetTarget.WINNER)
+
+
+def test_final_bet_rejects_unknown_target() -> None:
+    invalid_target = cast(FinalBetTarget, "podium")
+
+    with pytest.raises(ValueError, match="winner or loser"):
+        place_final_bet(_setup_state(), 0, CamelId.RED, invalid_target)
+
+
+@pytest.mark.parametrize("bet_kind", ["leg", "final"])
+@pytest.mark.parametrize("state_kind", ["pre-setup", "leg-complete", "terminal"])
+def test_betting_rejects_inactive_game_states(
+    bet_kind: str,
+    state_kind: str,
+) -> None:
+    if state_kind == "pre-setup":
+        state = GameState.pre_setup()
+        message = "setup"
+    elif state_kind == "leg-complete":
+        state = replace(_setup_state(), remaining_dice=(DieId.GREY,))
+        message = "leg is complete"
+    else:
+        state = replace(_setup_state(), terminal=True)
+        message = "game has ended"
+
+    with pytest.raises(ValueError, match=message):
+        if bet_kind == "leg":
+            take_leg_betting_ticket(state, 0, CamelId.RED)
+        else:
+            place_final_bet(state, 0, CamelId.RED, FinalBetTarget.WINNER)
+
+
+def test_game_rejects_noncanonical_available_ticket_order() -> None:
+    state = GameState.pre_setup()
+    tickets = state.available_leg_betting_tickets
+
+    with pytest.raises(ValueError, match="canonical order"):
+        replace(
+            state,
+            available_leg_betting_tickets=(tickets[1], tickets[0], *tickets[2:]),
+        )
+
+
+def test_game_rejects_missing_or_duplicated_leg_tickets() -> None:
+    state = GameState.pre_setup()
+
+    with pytest.raises(ValueError, match="conserve the initial supply"):
+        replace(
+            state,
+            available_leg_betting_tickets=state.available_leg_betting_tickets[1:],
+        )
+
+    with pytest.raises(ValueError, match="conserve the initial supply"):
+        replace(
+            state,
+            available_leg_betting_tickets=(
+                state.available_leg_betting_tickets[0],
+                *state.available_leg_betting_tickets,
+            ),
+        )
+
+
+def test_game_rejects_finish_card_missing_from_both_locations() -> None:
+    state = GameState.pre_setup()
+    player = replace(
+        state.players[0],
+        available_finish_cards=RACING_CAMEL_ORDER[1:],
+    )
+
+    with pytest.raises(ValueError, match="conserve one card"):
+        replace(state, players=(player, *state.players[1:]))
+
+
+def test_game_rejects_duplicated_or_unknown_final_bets() -> None:
+    state = place_final_bet(
+        _setup_state(),
+        player_id=0,
+        camel=CamelId.RED,
+        target=FinalBetTarget.WINNER,
+    )
+    bet = state.final_winner_bets[0]
+
+    with pytest.raises(ValueError, match="conserve one card"):
+        replace(state, final_loser_bets=(bet,))
+
+    with pytest.raises(ValueError, match="belong to a player"):
+        replace(
+            state,
+            final_loser_bets=(FinalBet(player_id=MIN_PLAYERS, camel=CamelId.BLUE),),
+        )
+
+
+def test_equivalent_betting_histories_are_hashable() -> None:
+    first = place_final_bet(
+        take_leg_betting_ticket(_setup_state(), 0, CamelId.RED),
+        1,
+        CamelId.BLUE,
+        FinalBetTarget.LOSER,
+    )
+    second = place_final_bet(
+        take_leg_betting_ticket(_setup_state(), 0, CamelId.RED),
+        1,
+        CamelId.BLUE,
+        FinalBetTarget.LOSER,
+    )
+
+    assert first == second
+    assert hash(first) == hash(second)
+    assert {first: "recorded"}[second] == "recorded"


### PR DESCRIPTION
## Outcome

Add deterministic, immutable leg and final bet placement on top of the player-state foundation.

## Changes

- add one canonical bottom-to-top 2, 2, 3, 5 leg-ticket stack for every racing camel
- add separate ordered final winner and loser bet records
- enforce conservation of every betting ticket and finish card in `GameState`
- add queries and transitions for ticket availability, top-ticket taking, and final bet placement
- preserve player balances during placement; payouts remain deferred
- document the public API and split the later scoring work into focused PRs
- add focused coverage for exhaustion, ordering, invalid states, immutability, equality, and hashing

## Non-goals

- leg or final payouts
- camel ranking
- leg reset orchestration
- legal actions or turn advancement
- CLI, agent, or RL integration

## Reviewability

The implementation and its conservation tests are kept together because separating the state invariants from the only transitions that exercise them would leave an unused intermediate model and duplicate the same asset-ownership review across PRs.

## Verification

- `uv run python -m pytest` — 99 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python -m mypy`