### PR TITLE
feat: add leg ranking and settlement

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,20 @@ state = place_final_bet(
 ```
 
 Both operations return a new state and leave their input unchanged. Placing a
-bet does not cost money. Betting settlement is not implemented yet, so these
-operations record player choices without applying payouts.
+bet does not cost money. Once a leg reaches its scoring boundary, use the
+scoring API to inspect the racing order and settle its betting assets:
+
+```python
+from camel_up.engine import rank_racing_camels, settle_leg
+
+ranking = rank_racing_camels(state.board)
+state = settle_leg(state)
+```
+
+`ranking` lists only racing camels from first to last; crazy camels are ignored.
+`settle_leg` applies leg-ticket and pyramid-ticket payouts, floors balances at
+zero, and resets only the consumed leg betting assets. Dice, spectator tiles,
+turn progression, and final-race settlement remain separate rule transitions.
 
 ## Agent Compatibility
 

--- a/README.md
+++ b/README.md
@@ -107,20 +107,9 @@ state = place_final_bet(
 ```
 
 Both operations return a new state and leave their input unchanged. Placing a
-bet does not cost money. Once a leg reaches its scoring boundary, use the
-scoring API to inspect the racing order and settle its betting assets:
-
-```python
-from camel_up.engine import rank_racing_camels, settle_leg
-
-ranking = rank_racing_camels(state.board)
-state = settle_leg(state)
-```
-
-`ranking` lists only racing camels from first to last; crazy camels are ignored.
-`settle_leg` applies leg-ticket and pyramid-ticket payouts, floors balances at
-zero, and resets only the consumed leg betting assets. Dice, spectator tiles,
-turn progression, and final-race settlement remain separate rule transitions.
+bet does not cost money. `settle_leg` applies leg-ticket and pyramid-ticket
+payouts at a scoring boundary and resets the consumed leg betting assets.
+Turn orchestration and final-race settlement remain later engine milestones.
 
 ## Agent Compatibility
 

--- a/docs/software-foundation-plan.md
+++ b/docs/software-foundation-plan.md
@@ -424,6 +424,8 @@ Non-goals:
 
 #### PR 5b: `feat: add leg ranking and settlement`
 
+Status: `Done`
+
 Suggested branch: `feat/leg-scoring`
 
 Goal: Score one leg deterministically using the stable board, player, and
@@ -431,17 +433,17 @@ betting state from PR 5a.
 
 Tasks:
 
-- [ ] Add `engine.scoring` racing-camel ordering that excludes crazy camels and
+- [x] Add `engine.scoring` racing-camel ordering that excludes crazy camels and
       handles shared stacks and both finish zones.
-- [ ] Add immutable leg settlement for printed leg-ticket payouts, second-place
+- [x] Add immutable leg settlement for printed leg-ticket payouts, second-place
       payouts, losing-ticket penalties, and pyramid-ticket income.
-- [ ] Clear held leg tickets and pyramid-ticket counts and restore the canonical
+- [x] Clear held leg tickets and pyramid-ticket counts and restore the canonical
       shared leg-ticket supplies after settlement.
-- [ ] Preserve race-long state, including money after settlement, final-bet
+- [x] Preserve race-long state, including money after settlement, final-bet
       records, unused finish cards, camel positions, and terminal status.
-- [ ] Leave dice reset, spectator-tile return, leg-number advancement, and
+- [x] Leave dice reset, spectator-tile return, leg-number advancement, and
       current-player advancement to turn orchestration.
-- [ ] Add focused tests for stack-based first and second place, crazy-camel
+- [x] Add focused tests for stack-based first and second place, crazy-camel
       interactions, every payout category, zero-balance flooring, and betting
       asset reset boundaries.
 

--- a/src/camel_up/engine/__init__.py
+++ b/src/camel_up/engine/__init__.py
@@ -13,6 +13,7 @@ from camel_up.engine.dice import (
     setup_game,
 )
 from camel_up.engine.movement import move_camel
+from camel_up.engine.scoring import rank_racing_camels, settle_leg
 from camel_up.engine.state import (
     CAMEL_ORDER,
     DIE_ORDER,
@@ -60,9 +61,11 @@ __all__ = [
     "move_camel",
     "position_of",
     "place_final_bet",
+    "rank_racing_camels",
     "reset_leg_dice",
     "roll_die",
     "setup_game",
+    "settle_leg",
     "spectator_tile_for_player",
     "stack_at",
     "take_leg_betting_ticket",

--- a/src/camel_up/engine/scoring.py
+++ b/src/camel_up/engine/scoring.py
@@ -47,6 +47,9 @@ def rank_racing_camels(board: BoardState) -> tuple[CamelId, ...]:
 def settle_leg(state: GameState) -> GameState:
     """Apply leg payouts and reset only the consumed leg betting assets.
 
+    This is a scoring-only transition. It leaves the board and remaining dice
+    unchanged and does not start the next leg.
+
     A regular leg can be settled after five dice have been used. A terminal
     game can be settled immediately because crossing either finish line ends
     the current leg regardless of how many dice remain.

--- a/src/camel_up/engine/scoring.py
+++ b/src/camel_up/engine/scoring.py
@@ -1,0 +1,119 @@
+"""Deterministic racing-camel ranking and leg settlement rules."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from camel_up.engine.state import (
+    INITIAL_LEG_BETTING_TICKET_STACKS,
+    RACING_CAMEL_ORDER,
+    BoardState,
+    CamelId,
+    GameState,
+    PlayerState,
+    position_of,
+)
+
+
+def rank_racing_camels(board: BoardState) -> tuple[CamelId, ...]:
+    """Return racing camels from first to last for the current board.
+
+    Crazy camels are excluded. Racing camels farther along the track rank
+    ahead, and a racing camel higher in a shared stack ranks ahead of racing
+    camels below it. These rules also apply in the forward and backward finish
+    zones.
+
+    Args:
+        board: Fully populated board whose racing camels should be ranked.
+
+    Returns:
+        The five racing camel identities ordered from first to last.
+
+    Raises:
+        ValueError: If initial camel placement has not been completed.
+    """
+    if not all(position.is_placed for position in board.camel_positions):
+        raise ValueError("initial setup must be completed before ranking camels")
+
+    return tuple(
+        sorted(
+            RACING_CAMEL_ORDER,
+            key=lambda camel: _race_progress(board, camel),
+            reverse=True,
+        )
+    )
+
+
+def settle_leg(state: GameState) -> GameState:
+    """Apply leg payouts and reset only the consumed leg betting assets.
+
+    A regular leg can be settled after five dice have been used. A terminal
+    game can be settled immediately because crossing either finish line ends
+    the current leg regardless of how many dice remain.
+
+    Ticket gains and losses plus pyramid-ticket income are combined for each
+    player before applying the rule that money cannot fall below zero. The
+    returned state clears held leg tickets and pyramid-ticket counts and
+    restores the shared ticket supplies. Dice, spectator tiles, turn fields,
+    final bets, camel positions, and terminal status are preserved for the
+    future turn-orchestration layer.
+
+    Args:
+        state: Completed leg whose betting assets should be settled.
+
+    Returns:
+        A replacement state with updated balances and reset leg betting assets.
+
+    Raises:
+        ValueError: If setup is incomplete or a non-terminal leg is unfinished.
+    """
+    _validate_leg_settlement(state)
+    first, second, *_ = rank_racing_camels(state.board)
+    players = tuple(
+        _settle_player(player, first=first, second=second) for player in state.players
+    )
+    return replace(
+        state,
+        players=players,
+        available_leg_betting_tickets=INITIAL_LEG_BETTING_TICKET_STACKS,
+    )
+
+
+def _race_progress(board: BoardState, camel: CamelId) -> tuple[int, int]:
+    """Return a sortable racing progress coordinate for one placed camel."""
+    position = position_of(board, camel)
+    if position.space is None or position.level is None:
+        raise ValueError("initial setup must be completed before ranking camels")
+    return position.space, position.level
+
+
+def _settle_player(
+    player: PlayerState,
+    *,
+    first: CamelId,
+    second: CamelId,
+) -> PlayerState:
+    """Return one player with their combined leg result applied."""
+    payout = player.pyramid_ticket_count
+    for ticket in player.leg_betting_tickets:
+        if ticket.camel is first:
+            payout += ticket.value
+        elif ticket.camel is second:
+            payout += 1
+        else:
+            payout -= 1
+
+    return replace(
+        player,
+        money=max(0, player.money + payout),
+        pyramid_ticket_count=0,
+        leg_betting_tickets=(),
+    )
+
+
+def _validate_leg_settlement(state: GameState) -> None:
+    """Reject states that have not reached a scoring boundary."""
+    if not all(position.is_placed for position in state.board.camel_positions):
+        raise ValueError("initial setup must be completed before settling a leg")
+    if not state.terminal and len(state.remaining_dice) != 1:
+        raise ValueError("a leg can only be settled after five dice have been used")

--- a/src/camel_up/engine/scoring.py
+++ b/src/camel_up/engine/scoring.py
@@ -83,7 +83,7 @@ def _race_progress(board: BoardState, camel: CamelId) -> tuple[int, int]:
     """Return a sortable racing progress coordinate for one placed camel."""
     position = position_of(board, camel)
     if position.space is None or position.level is None:
-        raise ValueError("initial setup must be completed before ranking camels")
+        raise ValueError(f"{camel.value} camel must be placed before ranking camels")
     return position.space, position.level
 
 
@@ -116,4 +116,8 @@ def _validate_leg_settlement(state: GameState) -> None:
     if not all(position.is_placed for position in state.board.camel_positions):
         raise ValueError("initial setup must be completed before settling a leg")
     if not state.terminal and len(state.remaining_dice) != 1:
-        raise ValueError("a leg can only be settled after five dice have been used")
+        raise ValueError(
+            "cannot settle an unfinished leg: state is non-terminal with "
+            f"{len(state.remaining_dice)} dice remaining; expected one remaining "
+            "die or a terminal game"
+        )

--- a/tests/engine/test_scoring.py
+++ b/tests/engine/test_scoring.py
@@ -212,6 +212,12 @@ def test_leg_settlement_preserves_race_long_and_orchestration_state() -> None:
 
     settled = settle_leg(state)
 
+    # Settlement changes balances and consumes leg-scoped betting assets.
+    assert settled != state
+    assert settled.players[1] != state.players[1]
+    assert settled.available_leg_betting_tickets != state.available_leg_betting_tickets
+
+    # It does not perform the wider leg or turn transition.
     assert settled.board == state.board
     assert settled.remaining_dice == state.remaining_dice
     assert settled.current_player == state.current_player

--- a/tests/engine/test_scoring.py
+++ b/tests/engine/test_scoring.py
@@ -93,7 +93,11 @@ def test_ranking_excludes_crazy_camels_and_uses_physical_stack_level() -> None:
 def test_ranking_handles_forward_and_backward_finish_zone_stacks() -> None:
     board = _board_with_stacks(
         {
-            -1: (CamelId.BLACK, CamelId.PURPLE, CamelId.GREEN),
+            -1: (  # Backward finish zone.
+                CamelId.BLACK,
+                CamelId.PURPLE,
+                CamelId.GREEN,
+            ),
             15: (CamelId.YELLOW,),
             16: (CamelId.WHITE, CamelId.RED, CamelId.BLUE),
         }
@@ -139,7 +143,6 @@ def test_leg_settlement_applies_every_payout_and_resets_betting_assets() -> None
     )
     assert state.players[0].money == 3
     assert len(state.players[0].leg_betting_tickets) == 6
-    assert settle_leg(settled) == settled
 
 
 def test_leg_result_is_combined_before_money_is_floored_at_zero() -> None:
@@ -156,6 +159,35 @@ def test_leg_result_is_combined_before_money_is_floored_at_zero() -> None:
     # The losing ticket and pyramid ticket net to zero. Flooring the loss
     # before adding the income would incorrectly leave the player with 1 EP.
     assert settled.players[0].money == 0
+
+
+def test_leg_settlement_floors_a_negative_balance_at_zero() -> None:
+    state = take_leg_betting_ticket(_active_state(), 0, CamelId.GREEN)
+    player = replace(state.players[0], money=0)
+    state = replace(
+        state,
+        players=(player, *state.players[1:]),
+        remaining_dice=(DieId.YELLOW,),
+    )
+
+    settled = settle_leg(state)
+
+    assert settled.players[0].money == 0
+
+
+def test_repeated_leg_settlement_does_not_credit_players_again() -> None:
+    state = take_leg_betting_ticket(_active_state(), 0, CamelId.RED)
+    player = replace(state.players[0], pyramid_ticket_count=2)
+    state = replace(
+        state,
+        players=(player, *state.players[1:]),
+        remaining_dice=(DieId.YELLOW,),
+    )
+
+    settled = settle_leg(state)
+
+    assert settled.players[0].money == 10
+    assert settle_leg(settled) == settled
 
 
 def test_leg_settlement_preserves_race_long_and_orchestration_state() -> None:
@@ -217,5 +249,8 @@ def test_leg_settlement_rejects_pre_setup_and_unfinished_leg() -> None:
     with pytest.raises(ValueError, match="setup must be completed"):
         settle_leg(GameState.pre_setup())
 
-    with pytest.raises(ValueError, match="after five dice"):
+    with pytest.raises(
+        ValueError,
+        match="non-terminal with 6 dice remaining",
+    ):
         settle_leg(_active_state())

--- a/tests/engine/test_scoring.py
+++ b/tests/engine/test_scoring.py
@@ -1,0 +1,221 @@
+from dataclasses import replace
+
+import pytest
+
+from camel_up.engine import (
+    CAMEL_ORDER,
+    DIE_ORDER,
+    MIN_PLAYERS,
+    BoardState,
+    CamelId,
+    CamelPosition,
+    DieId,
+    FinalBetTarget,
+    GameState,
+    PlayerState,
+    SpectatorTile,
+    place_final_bet,
+    rank_racing_camels,
+    settle_leg,
+    take_leg_betting_ticket,
+)
+
+
+def _board_with_stacks(
+    stacks: dict[int, tuple[CamelId, ...]],
+    *,
+    spectator_tiles: tuple[SpectatorTile, ...] = (),
+) -> BoardState:
+    """Build a complete board from bottom-to-top test stack definitions."""
+    positions_by_camel: dict[CamelId, CamelPosition] = {}
+    for space, stack in stacks.items():
+        for level, camel in enumerate(stack):
+            if camel in positions_by_camel:
+                raise ValueError("test stacks cannot place a camel more than once")
+            positions_by_camel[camel] = CamelPosition(space=space, level=level)
+
+    if set(positions_by_camel) != set(CAMEL_ORDER):
+        raise ValueError("test stacks must place every camel exactly once")
+    return BoardState(
+        track_length=16,
+        camel_positions=tuple(positions_by_camel[camel] for camel in CAMEL_ORDER),
+        spectator_tiles=spectator_tiles,
+    )
+
+
+def _players() -> tuple[PlayerState, ...]:
+    return tuple(PlayerState(player_id=index) for index in range(MIN_PLAYERS))
+
+
+def _active_state(*, spectator_tile: bool = False) -> GameState:
+    tiles = (SpectatorTile(player_id=2, space=3, effect=-1),) if spectator_tile else ()
+    board = _board_with_stacks(
+        {
+            5: (CamelId.PURPLE,),
+            6: (CamelId.YELLOW,),
+            7: (CamelId.GREEN,),
+            8: (
+                CamelId.WHITE,
+                CamelId.BLUE,
+                CamelId.BLACK,
+                CamelId.RED,
+            ),
+        },
+        spectator_tiles=tiles,
+    )
+    return GameState(board=board, players=_players())
+
+
+def test_ranking_excludes_crazy_camels_and_uses_physical_stack_level() -> None:
+    board = _board_with_stacks(
+        {
+            6: (CamelId.PURPLE,),
+            7: (CamelId.YELLOW,),
+            8: (
+                CamelId.BLUE,
+                CamelId.WHITE,
+                CamelId.RED,
+                CamelId.BLACK,
+                CamelId.GREEN,
+            ),
+        }
+    )
+
+    assert rank_racing_camels(board) == (
+        CamelId.GREEN,
+        CamelId.RED,
+        CamelId.BLUE,
+        CamelId.YELLOW,
+        CamelId.PURPLE,
+    )
+
+
+def test_ranking_handles_forward_and_backward_finish_zone_stacks() -> None:
+    board = _board_with_stacks(
+        {
+            -1: (CamelId.BLACK, CamelId.PURPLE, CamelId.GREEN),
+            15: (CamelId.YELLOW,),
+            16: (CamelId.WHITE, CamelId.RED, CamelId.BLUE),
+        }
+    )
+
+    assert rank_racing_camels(board) == (
+        CamelId.BLUE,
+        CamelId.RED,
+        CamelId.YELLOW,
+        CamelId.GREEN,
+        CamelId.PURPLE,
+    )
+
+
+def test_ranking_rejects_pre_setup_board() -> None:
+    with pytest.raises(ValueError, match="setup must be completed"):
+        rank_racing_camels(BoardState.empty())
+
+
+def test_leg_settlement_applies_every_payout_and_resets_betting_assets() -> None:
+    state = _active_state()
+    for _ in range(4):
+        state = take_leg_betting_ticket(state, 0, CamelId.RED)
+    state = take_leg_betting_ticket(state, 0, CamelId.BLUE)
+    state = take_leg_betting_ticket(state, 0, CamelId.GREEN)
+    players = (
+        replace(state.players[0], pyramid_ticket_count=2),
+        replace(state.players[1], money=4, pyramid_ticket_count=3),
+        state.players[2],
+    )
+    state = replace(state, players=players, remaining_dice=(DieId.GREY,))
+
+    settled = settle_leg(state)
+
+    # Red leads: 5 + 3 + 2 + 2. Blue is second: +1. Green loses: -1.
+    # Two pyramid tickets bring player zero's total leg payout to 14 EP.
+    assert tuple(player.money for player in settled.players) == (17, 7, 3)
+    assert all(not player.leg_betting_tickets for player in settled.players)
+    assert all(player.pyramid_ticket_count == 0 for player in settled.players)
+    assert (
+        settled.available_leg_betting_tickets
+        == GameState.pre_setup().available_leg_betting_tickets
+    )
+    assert state.players[0].money == 3
+    assert len(state.players[0].leg_betting_tickets) == 6
+    assert settle_leg(settled) == settled
+
+
+def test_leg_result_is_combined_before_money_is_floored_at_zero() -> None:
+    state = take_leg_betting_ticket(_active_state(), 0, CamelId.GREEN)
+    player = replace(state.players[0], money=0, pyramid_ticket_count=1)
+    state = replace(
+        state,
+        players=(player, *state.players[1:]),
+        remaining_dice=(DieId.YELLOW,),
+    )
+
+    settled = settle_leg(state)
+
+    # The losing ticket and pyramid ticket net to zero. Flooring the loss
+    # before adding the income would incorrectly leave the player with 1 EP.
+    assert settled.players[0].money == 0
+
+
+def test_leg_settlement_preserves_race_long_and_orchestration_state() -> None:
+    state = take_leg_betting_ticket(_active_state(spectator_tile=True), 1, CamelId.RED)
+    state = place_final_bet(
+        state,
+        player_id=1,
+        camel=CamelId.GREEN,
+        target=FinalBetTarget.WINNER,
+    )
+    state = replace(
+        state,
+        players=(
+            state.players[0],
+            replace(state.players[1], pyramid_ticket_count=2),
+            state.players[2],
+        ),
+        remaining_dice=(DieId.BLUE,),
+        current_player=2,
+        leg_number=4,
+    )
+
+    settled = settle_leg(state)
+
+    assert settled.board == state.board
+    assert settled.remaining_dice == state.remaining_dice
+    assert settled.current_player == state.current_player
+    assert settled.leg_number == state.leg_number
+    assert settled.terminal == state.terminal
+    assert settled.final_winner_bets == state.final_winner_bets
+    assert settled.final_loser_bets == state.final_loser_bets
+    assert tuple(player.available_finish_cards for player in settled.players) == tuple(
+        player.available_finish_cards for player in state.players
+    )
+
+
+def test_terminal_race_can_settle_before_five_dice_have_been_used() -> None:
+    state = take_leg_betting_ticket(_active_state(), 0, CamelId.RED)
+    terminal_board = _board_with_stacks(
+        {
+            5: (CamelId.PURPLE,),
+            6: (CamelId.YELLOW,),
+            7: (CamelId.GREEN,),
+            12: (CamelId.WHITE,),
+            14: (CamelId.BLACK,),
+            16: (CamelId.BLUE, CamelId.RED),
+        }
+    )
+    state = replace(state, board=terminal_board, terminal=True)
+
+    settled = settle_leg(state)
+
+    assert settled.players[0].money == 8
+    assert settled.remaining_dice == DIE_ORDER
+    assert settled.terminal
+
+
+def test_leg_settlement_rejects_pre_setup_and_unfinished_leg() -> None:
+    with pytest.raises(ValueError, match="setup must be completed"):
+        settle_leg(GameState.pre_setup())
+
+    with pytest.raises(ValueError, match="after five dice"):
+        settle_leg(_active_state())


### PR DESCRIPTION
## Outcome

Add deterministic racing-camel ranking and immutable leg settlement using the betting state introduced in PR 5a.

## Changes

- rank racing camels first-to-last while excluding crazy camels and respecting stack levels and finish zones
- settle printed leg-ticket payouts, second-place payouts, losing-ticket penalties, and pyramid-ticket income
- floor player balances at zero and reset only leg-scoped betting assets
- preserve dice, spectator tiles, turn fields, final bets, camel positions, and terminal status
- expose the scoring API and document the completed PR 5b milestone

## Non-goals

- final winner or loser settlement
- dice or spectator-tile reset
- leg-number or current-player advancement
- legal actions, CLI migration, agents, or RL environments

## Verification

- 107 tests passed
- Ruff lint passed
- Ruff format check passed
- mypy passed
- git diff check passed