### PR TITLE
feat: add final race settlement

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,14 +106,14 @@ state = place_final_bet(
     target=FinalBetTarget.WINNER,
 )
 
-# Settle the final records after camel movement ends the game.
-state = settle_final_bets(state)
+if state.terminal:
+    state = settle_final_bets(state)
 ```
 
-Both operations return a new state and leave their input unchanged. Placing a
-bet does not cost money. `settle_leg` applies leg-ticket and pyramid-ticket
-payouts at a scoring boundary and resets the consumed leg betting assets.
-Call `settle_final_bets` on a terminal state to score the final winner and loser
+Betting transitions return a new state and leave their input unchanged. Placing
+a bet does not cost money. `settle_leg` applies leg-ticket and pyramid-ticket
+payouts at a scoring boundary and resets the consumed leg betting assets. Call
+`settle_final_bets` on a terminal state to score the final winner and loser
 records.
 
 ## Agent Compatibility

--- a/README.md
+++ b/README.md
@@ -106,16 +106,15 @@ state = place_final_bet(
     target=FinalBetTarget.WINNER,
 )
 
-# Once camel movement has made the game terminal:
+# Settle the final records after camel movement ends the game.
 state = settle_final_bets(state)
 ```
 
 Both operations return a new state and leave their input unchanged. Placing a
 bet does not cost money. `settle_leg` applies leg-ticket and pyramid-ticket
 payouts at a scoring boundary and resets the consumed leg betting assets.
-`settle_final_bets` scores the terminal winner and loser records in placement
-order, preserves their history, and prevents duplicate settlement. Turn
-orchestration remains a later engine milestone.
+Call `settle_final_bets` on a terminal state to score the final winner and loser
+records.
 
 ## Agent Compatibility
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ from camel_up.engine import (
     CamelId,
     FinalBetTarget,
     place_final_bet,
+    settle_final_bets,
     take_leg_betting_ticket,
 )
 
@@ -104,12 +105,17 @@ state = place_final_bet(
     camel=CamelId.GREEN,
     target=FinalBetTarget.WINNER,
 )
+
+# Once camel movement has made the game terminal:
+state = settle_final_bets(state)
 ```
 
 Both operations return a new state and leave their input unchanged. Placing a
 bet does not cost money. `settle_leg` applies leg-ticket and pyramid-ticket
 payouts at a scoring boundary and resets the consumed leg betting assets.
-Turn orchestration and final-race settlement remain later engine milestones.
+`settle_final_bets` scores the terminal winner and loser records in placement
+order, preserves their history, and prevents duplicate settlement. Turn
+orchestration remains a later engine milestone.
 
 ## Agent Compatibility
 

--- a/docs/software-foundation-plan.md
+++ b/docs/software-foundation-plan.md
@@ -467,6 +467,8 @@ Non-goals:
 
 #### PR 5c: `feat: add final race settlement`
 
+Status: `Done`
+
 Suggested branch: `feat/final-race-scoring`
 
 Goal: Settle ordered final winner and loser bets for a terminal race using the
@@ -474,15 +476,15 @@ ranking and betting contracts established by PRs 5a and 5b.
 
 Tasks:
 
-- [ ] Determine the winning and losing racing camels from the canonical race
+- [x] Determine the winning and losing racing camels from the canonical race
       order, including same-stack and backward-finish cases.
-- [ ] Score final winner and loser records independently in placement order
+- [x] Score final winner and loser records independently in placement order
       using the canonical 8, 5, 3, 2, then 1 payout sequence.
-- [ ] Apply incorrect-bet penalties without allowing negative balances.
-- [ ] Record final-settlement completion in `GameState`, reject non-terminal or
+- [x] Apply incorrect-bet penalties without allowing negative balances.
+- [x] Record final-settlement completion in `GameState`, reject non-terminal or
       already-settled input, and preserve immutable bet history for replay and
       audit.
-- [ ] Add focused tests for ordered correct payouts, incorrect bets, more than
+- [x] Add focused tests for ordered correct payouts, incorrect bets, more than
       four correct bets, same-stack winner and loser selection, backward finish,
       and deterministic balance updates.
 
@@ -648,7 +650,7 @@ High-priority areas:
 - [ ] Spectator tile movement effects.
 - [ ] Leg reset behavior.
 - [x] End-of-game detection.
-- [ ] Winner and runner-up ordering.
+- [x] Winner and runner-up ordering.
 - [ ] Legal actions and legal action masks.
 - [x] Determinism with fixed seeds.
 

--- a/src/camel_up/engine/__init__.py
+++ b/src/camel_up/engine/__init__.py
@@ -13,7 +13,7 @@ from camel_up.engine.dice import (
     setup_game,
 )
 from camel_up.engine.movement import move_camel
-from camel_up.engine.scoring import rank_racing_camels, settle_leg
+from camel_up.engine.scoring import rank_racing_camels, settle_final_bets, settle_leg
 from camel_up.engine.state import (
     CAMEL_ORDER,
     DIE_ORDER,
@@ -65,6 +65,7 @@ __all__ = [
     "reset_leg_dice",
     "roll_die",
     "setup_game",
+    "settle_final_bets",
     "settle_leg",
     "spectator_tile_for_player",
     "stack_at",

--- a/src/camel_up/engine/scoring.py
+++ b/src/camel_up/engine/scoring.py
@@ -1,4 +1,4 @@
-"""Deterministic racing-camel ranking and leg settlement rules."""
+"""Deterministic racing-camel ranking and settlement rules."""
 
 from __future__ import annotations
 
@@ -9,10 +9,13 @@ from camel_up.engine.state import (
     RACING_CAMEL_ORDER,
     BoardState,
     CamelId,
+    FinalBet,
     GameState,
     PlayerState,
     position_of,
 )
+
+_FINAL_BET_PAYOUTS = (8, 5, 3, 2)
 
 
 def rank_racing_camels(board: BoardState) -> tuple[CamelId, ...]:
@@ -82,6 +85,42 @@ def settle_leg(state: GameState) -> GameState:
     )
 
 
+def settle_final_bets(state: GameState) -> GameState:
+    """Apply final winner and loser bet payouts to a terminal game.
+
+    Winner and loser records are scored independently in placement order.
+    Correct bets receive 8, 5, 3, and 2 Egyptian Pounds, followed by 1 for
+    every later correct bet. Incorrect bets do not consume a payout position
+    and lose 1 Egyptian Pound. All of a player's final-bet results are combined
+    before their balance is floored at zero.
+
+    This scoring-only transition preserves both ordered bet records for replay
+    and audit. It marks them as settled so the same terminal state cannot be
+    credited twice.
+
+    Args:
+        state: Terminal game whose final betting records should be settled.
+
+    Returns:
+        A replacement state with updated balances and completed settlement.
+
+    Raises:
+        ValueError: If the game is non-terminal, setup is incomplete, or final
+            bets have already been settled.
+    """
+    _validate_final_settlement(state)
+    ranking = rank_racing_camels(state.board)
+    payouts = [0] * len(state.players)
+    _score_final_bet_record(state.final_winner_bets, ranking[0], payouts)
+    _score_final_bet_record(state.final_loser_bets, ranking[-1], payouts)
+
+    players = tuple(
+        replace(player, money=max(0, player.money + payouts[player.player_id]))
+        for player in state.players
+    )
+    return replace(state, players=players, final_bets_settled=True)
+
+
 def _race_progress(board: BoardState, camel: CamelId) -> tuple[int, int]:
     """Return a sortable racing progress coordinate for one placed camel."""
     position = position_of(board, camel)
@@ -114,6 +153,26 @@ def _settle_player(
     )
 
 
+def _score_final_bet_record(
+    bets: tuple[FinalBet, ...],
+    result: CamelId,
+    payouts: list[int],
+) -> None:
+    """Accumulate one ordered winner or loser record into player payouts."""
+    correct_bet_count = 0
+    for bet in bets:
+        if bet.camel is result:
+            payout = (
+                _FINAL_BET_PAYOUTS[correct_bet_count]
+                if correct_bet_count < len(_FINAL_BET_PAYOUTS)
+                else 1
+            )
+            payouts[bet.player_id] += payout
+            correct_bet_count += 1
+        else:
+            payouts[bet.player_id] -= 1
+
+
 def _validate_leg_settlement(state: GameState) -> None:
     """Reject states that have not reached a scoring boundary."""
     if not all(position.is_placed for position in state.board.camel_positions):
@@ -124,3 +183,13 @@ def _validate_leg_settlement(state: GameState) -> None:
             f"{len(state.remaining_dice)} dice remaining; expected one remaining "
             "die or a terminal game"
         )
+
+
+def _validate_final_settlement(state: GameState) -> None:
+    """Reject states outside the one valid final-settlement boundary."""
+    if not state.terminal:
+        raise ValueError("cannot settle final bets before the game has ended")
+    if state.final_bets_settled:
+        raise ValueError("final bets have already been settled")
+    if not all(position.is_placed for position in state.board.camel_positions):
+        raise ValueError("initial setup must be completed before settling final bets")

--- a/src/camel_up/engine/scoring.py
+++ b/src/camel_up/engine/scoring.py
@@ -110,9 +110,17 @@ def settle_final_bets(state: GameState) -> GameState:
     """
     _validate_final_settlement(state)
     ranking = rank_racing_camels(state.board)
-    payouts = [0] * len(state.players)
-    _score_final_bet_record(state.final_winner_bets, ranking[0], payouts)
-    _score_final_bet_record(state.final_loser_bets, ranking[-1], payouts)
+    payouts = (0,) * len(state.players)
+    payouts = _score_final_bet_record(
+        state.final_winner_bets,
+        ranking[0],
+        payouts,
+    )
+    payouts = _score_final_bet_record(
+        state.final_loser_bets,
+        ranking[-1],
+        payouts,
+    )
 
     players = tuple(
         replace(player, money=max(0, player.money + payouts[player.player_id]))
@@ -156,9 +164,10 @@ def _settle_player(
 def _score_final_bet_record(
     bets: tuple[FinalBet, ...],
     result: CamelId,
-    payouts: list[int],
-) -> None:
-    """Accumulate one ordered winner or loser record into player payouts."""
+    payouts: tuple[int, ...],
+) -> tuple[int, ...]:
+    """Return payouts updated from one ordered winner or loser record."""
+    updated_payouts = list(payouts)
     correct_bet_count = 0
     for bet in bets:
         if bet.camel is result:
@@ -167,10 +176,11 @@ def _score_final_bet_record(
                 if correct_bet_count < len(_FINAL_BET_PAYOUTS)
                 else 1
             )
-            payouts[bet.player_id] += payout
+            updated_payouts[bet.player_id] += payout
             correct_bet_count += 1
         else:
-            payouts[bet.player_id] -= 1
+            updated_payouts[bet.player_id] -= 1
+    return tuple(updated_payouts)
 
 
 def _validate_leg_settlement(state: GameState) -> None:

--- a/src/camel_up/engine/scoring.py
+++ b/src/camel_up/engine/scoring.py
@@ -110,16 +110,23 @@ def settle_final_bets(state: GameState) -> GameState:
     """
     _validate_final_settlement(state)
     ranking = rank_racing_camels(state.board)
-    payouts = (0,) * len(state.players)
-    payouts = _score_final_bet_record(
+    winner_payouts = _score_final_bet_record(
         state.final_winner_bets,
         ranking[0],
-        payouts,
+        player_count=len(state.players),
     )
-    payouts = _score_final_bet_record(
+    loser_payouts = _score_final_bet_record(
         state.final_loser_bets,
         ranking[-1],
-        payouts,
+        player_count=len(state.players),
+    )
+    payouts = tuple(
+        winner_payout + loser_payout
+        for winner_payout, loser_payout in zip(
+            winner_payouts,
+            loser_payouts,
+            strict=True,
+        )
     )
 
     players = tuple(
@@ -164,10 +171,11 @@ def _settle_player(
 def _score_final_bet_record(
     bets: tuple[FinalBet, ...],
     result: CamelId,
-    payouts: tuple[int, ...],
+    *,
+    player_count: int,
 ) -> tuple[int, ...]:
-    """Return payouts updated from one ordered winner or loser record."""
-    updated_payouts = list(payouts)
+    """Return player payout deltas for one winner or loser record."""
+    payouts = [0] * player_count
     correct_bet_count = 0
     for bet in bets:
         if bet.camel is result:
@@ -176,11 +184,11 @@ def _score_final_bet_record(
                 if correct_bet_count < len(_FINAL_BET_PAYOUTS)
                 else 1
             )
-            updated_payouts[bet.player_id] += payout
+            payouts[bet.player_id] += payout
             correct_bet_count += 1
         else:
-            updated_payouts[bet.player_id] -= 1
-    return tuple(updated_payouts)
+            payouts[bet.player_id] -= 1
+    return tuple(payouts)
 
 
 def _validate_leg_settlement(state: GameState) -> None:

--- a/src/camel_up/engine/state.py
+++ b/src/camel_up/engine/state.py
@@ -360,6 +360,7 @@ class GameState:
     )
     final_winner_bets: tuple[FinalBet, ...] = ()
     final_loser_bets: tuple[FinalBet, ...] = ()
+    final_bets_settled: bool = False
 
     @classmethod
     def pre_setup(
@@ -397,6 +398,8 @@ class GameState:
             raise ValueError("remaining_dice must be valid and use canonical order")
         if self.leg_number < 1:
             raise ValueError("leg_number must be positive")
+        if self.final_bets_settled and not self.terminal:
+            raise ValueError("final bets can only be settled for a terminal game")
         if not self.terminal and any(
             position.space in (-1, self.board.track_length)
             for position in self.board.camel_positions

--- a/src/camel_up/engine/state.py
+++ b/src/camel_up/engine/state.py
@@ -346,7 +346,9 @@ class GameState:
     Shared ticket supplies and ordered final betting records live here, while
     held tickets and unused finish cards live on their owning
     :class:`PlayerState`. Construction validates that those locations conserve
-    every betting asset.
+    every betting asset. Final bet records remain intact after scoring for
+    replay and audit, so ``final_bets_settled`` separately records completion
+    and prevents the same terminal state from paying them twice.
     """
 
     board: BoardState

--- a/tests/engine/test_scoring.py
+++ b/tests/engine/test_scoring.py
@@ -16,6 +16,7 @@ from camel_up.engine import (
     SpectatorTile,
     place_final_bet,
     rank_racing_camels,
+    settle_final_bets,
     settle_leg,
     take_leg_betting_ticket,
 )
@@ -43,11 +44,15 @@ def _board_with_stacks(
     )
 
 
-def _players() -> tuple[PlayerState, ...]:
-    return tuple(PlayerState(player_id=index) for index in range(MIN_PLAYERS))
+def _players(player_count: int = MIN_PLAYERS) -> tuple[PlayerState, ...]:
+    return tuple(PlayerState(player_id=index) for index in range(player_count))
 
 
-def _active_state(*, spectator_tile: bool = False) -> GameState:
+def _active_state(
+    *,
+    spectator_tile: bool = False,
+    player_count: int = MIN_PLAYERS,
+) -> GameState:
     tiles = (SpectatorTile(player_id=2, space=3, effect=-1),) if spectator_tile else ()
     board = _board_with_stacks(
         {
@@ -63,7 +68,20 @@ def _active_state(*, spectator_tile: bool = False) -> GameState:
         },
         spectator_tiles=tiles,
     )
-    return GameState(board=board, players=_players())
+    return GameState(board=board, players=_players(player_count))
+
+
+def _terminal_board() -> BoardState:
+    """Return a board where red won and purple lost across finish zones."""
+    return _board_with_stacks(
+        {
+            -1: (CamelId.BLACK, CamelId.PURPLE),
+            5: (CamelId.GREEN,),
+            6: (CamelId.YELLOW,),
+            7: (CamelId.BLUE,),
+            16: (CamelId.WHITE, CamelId.RED),
+        }
+    )
 
 
 def test_ranking_excludes_crazy_camels_and_uses_physical_stack_level() -> None:
@@ -260,3 +278,127 @@ def test_leg_settlement_rejects_pre_setup_and_unfinished_leg() -> None:
         match="non-terminal with 6 dice remaining",
     ):
         settle_leg(_active_state())
+
+
+def test_final_settlement_scores_ordered_records_independently() -> None:
+    state = _active_state(player_count=8)
+    winner_bets = (
+        (0, CamelId.BLUE),  # Incorrect bets do not consume payout positions.
+        (1, CamelId.RED),
+        (2, CamelId.RED),
+        (3, CamelId.GREEN),
+        (4, CamelId.RED),
+        (5, CamelId.RED),
+        (6, CamelId.RED),  # Fifth correct bet pays 1 EP.
+    )
+    loser_bets = (
+        (0, CamelId.YELLOW),
+        (2, CamelId.PURPLE),
+        (1, CamelId.BLUE),
+        (3, CamelId.PURPLE),
+    )
+    for player_id, camel in winner_bets:
+        state = place_final_bet(
+            state,
+            player_id,
+            camel,
+            FinalBetTarget.WINNER,
+        )
+    for player_id, camel in loser_bets:
+        state = place_final_bet(
+            state,
+            player_id,
+            camel,
+            FinalBetTarget.LOSER,
+        )
+    terminal = replace(state, board=_terminal_board(), terminal=True)
+
+    settled = settle_final_bets(terminal)
+
+    assert tuple(player.money for player in settled.players) == (
+        1,  # Two incorrect bets: 3 - 1 - 1.
+        10,  # First correct winner bet and one incorrect loser bet: 3 + 8 - 1.
+        16,  # Second correct winner and first correct loser: 3 + 5 + 8.
+        7,  # One incorrect winner and second correct loser: 3 - 1 + 5.
+        6,
+        5,
+        4,
+        3,
+    )
+    assert settled.final_bets_settled
+    assert settled.final_winner_bets == terminal.final_winner_bets
+    assert settled.final_loser_bets == terminal.final_loser_bets
+    assert not terminal.final_bets_settled
+    assert all(player.money == 3 for player in terminal.players)
+
+
+def test_final_settlement_uses_stack_order_at_both_finish_zones() -> None:
+    state = place_final_bet(
+        _active_state(),
+        player_id=0,
+        camel=CamelId.BLUE,
+        target=FinalBetTarget.WINNER,
+    )
+    state = place_final_bet(
+        state,
+        player_id=1,
+        camel=CamelId.PURPLE,
+        target=FinalBetTarget.LOSER,
+    )
+    terminal_board = _board_with_stacks(
+        {
+            -1: (CamelId.BLACK, CamelId.PURPLE, CamelId.GREEN),
+            15: (CamelId.YELLOW,),
+            16: (CamelId.WHITE, CamelId.RED, CamelId.BLUE),
+        }
+    )
+
+    settled = settle_final_bets(replace(state, board=terminal_board, terminal=True))
+
+    assert tuple(player.money for player in settled.players) == (11, 11, 3)
+
+
+def test_final_settlement_combines_results_before_flooring_money() -> None:
+    state = place_final_bet(
+        _active_state(),
+        player_id=0,
+        camel=CamelId.BLUE,
+        target=FinalBetTarget.WINNER,
+    )
+    state = place_final_bet(
+        state,
+        player_id=0,
+        camel=CamelId.YELLOW,
+        target=FinalBetTarget.LOSER,
+    )
+    players = (replace(state.players[0], money=0), *state.players[1:])
+
+    settled = settle_final_bets(
+        replace(state, board=_terminal_board(), players=players, terminal=True)
+    )
+
+    assert settled.players[0].money == 0
+
+
+def test_final_settlement_rejects_invalid_or_repeated_boundaries() -> None:
+    with pytest.raises(ValueError, match="before the game has ended"):
+        settle_final_bets(_active_state())
+
+    with pytest.raises(ValueError, match="setup must be completed"):
+        settle_final_bets(replace(GameState.pre_setup(), terminal=True))
+
+    settled = settle_final_bets(
+        replace(_active_state(), board=_terminal_board(), terminal=True)
+    )
+    with pytest.raises(ValueError, match="already been settled"):
+        settle_final_bets(settled)
+
+
+def test_equivalent_final_settlements_are_deterministic_and_hashable() -> None:
+    terminal = replace(_active_state(), board=_terminal_board(), terminal=True)
+
+    first = settle_final_bets(terminal)
+    second = settle_final_bets(terminal)
+
+    assert first == second
+    assert hash(first) == hash(second)

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -253,6 +253,11 @@ def test_finish_zone_requires_terminal_game_state() -> None:
     assert GameState(board=board, players=_players(), terminal=True).terminal
 
 
+def test_final_bet_settlement_marker_requires_terminal_game() -> None:
+    with pytest.raises(ValueError, match="terminal game"):
+        replace(GameState.pre_setup(), final_bets_settled=True)
+
+
 def test_legacy_components_preserve_prototype_stack_behavior() -> None:
     from components import Board, Camel
 


### PR DESCRIPTION
## Summary
- settle ordered final winner and loser bets using the canonical payout schedule
- prevent duplicate final settlement while preserving immutable bet history
- cover finish-zone stack ordering, penalties, payout order, and deterministic results
- update the roadmap and README for the completed milestone

## Non-goals
- legal actions and turn progression
- spectator tile rules
- CLI migration

## Validation
- uv run python -m pytest (115 passed)
- uv run ruff check .
- uv run ruff format --check .
- uv run python -m mypy