### PR TITLE
feat: add spectator tile rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,15 @@ state = move_camel(state, roll)
 `setup_game` constructs all seven camel positions atomically. Its ordered
 `setup_rolls` can be used for replay or presentation without exposing partially
 populated engine states. `move_camel` then applies the physical die result as a
-separate immutable transition, preserving carried-stack order and resolving
-the grey die's crazy-camel exceptions. Crossing either finish boundary places
-the moved unit in the corresponding finish zone and returns a terminal state.
-Spectator-tile movement effects are deferred to a later engine milestone;
-`move_camel` currently rejects a move that would require one.
+separate immutable transition, preserving carried-stack order, resolving the
+grey die's crazy-camel exceptions, and applying spectator-tile rewards and
+movement effects. Crossing either finish boundary places the moved unit in the
+corresponding finish zone and returns a terminal state.
+
+Use `place_spectator_tile` to place or move a player's cheering or booing tile.
+Tile placement and movement effects are deterministic rule transitions; turn
+ownership and full leg orchestration remain responsibilities of the future
+action layer.
 
 ## Betting API
 

--- a/docs/software-foundation-plan.md
+++ b/docs/software-foundation-plan.md
@@ -143,7 +143,7 @@ Tasks:
 - [x] Replace the mutable `Camel` and `Board` state model with canonical engine
       coordinates, retaining prototype adapters only while the CLI needs them.
 - [x] Introduce `GameState` before adding more rule behavior.
-- [ ] Put movement rules in `engine.movement`, dice rules in `engine.dice`,
+- [x] Put movement rules in `engine.movement`, dice rules in `engine.dice`,
       tile rules in `engine.tiles`, betting rules in `engine.betting`, and
       scoring rules in `engine.scoring`.
 - [x] Re-export only stable public functions and dataclasses from
@@ -508,28 +508,82 @@ Non-goals:
 - Action generation, turn orchestration, CLI migration, agents, and RL
   environments.
 
-#### PR 6: `feat: add legal actions and turn progression`
+The original legal-actions-and-turn-progression pull request crosses three
+stable rule boundaries. Implement it as PRs 6a through 6c so spectator-tile
+semantics stabilize before action indexing, and action indexing stabilizes
+before turn orchestration consumes it.
 
-Suggested branch: `feat/legal-actions-turns`
+#### PR 6a: `feat: add spectator tile rules`
+
+Status: `Done`
+
+Suggested branch: `feat/spectator-tile-rules`
+
+Goal: Complete deterministic spectator-tile placement, rewards, movement
+effects, and leg-boundary return transitions.
+
+Tasks:
+
+- [x] Add `engine.tiles` for immutable tile placement and replacement.
+- [x] Apply cheering and booing movement effects while preserving carried-stack
+      order and the booing tile's under-stack rule.
+- [x] Reverse tile displacement for crazy camels and credit the tile owner 1 EP.
+- [x] Keep a triggered tile on its space until the leg-boundary return
+      transition.
+- [x] Add focused tests for placement constraints, both movement effects, crazy
+      camels, stack ordering, owner rewards, finish crossings, and tile return.
+
+Acceptance criteria:
+
+- Tile placement and movement are immutable and deterministic.
+- A tile-triggered move preserves complete camel-unit ordering and valid stack
+  levels, including when a booing tile returns a unit to its source space.
+- Tile rules do not enforce current-player turns or perform full leg
+  orchestration.
+- All documented checks pass.
+
+Non-goals:
+
+- Typed actions, legal-action masks, turn progression, emitted events, CLI
+  migration, agents, and RL environments.
+
+#### PR 6b: `feat: add legal actions and masks`
+
+Suggested branch: `feat/legal-actions-masks`
+
+Goal: Define typed player choices and stable legal-action indices without
+applying turns.
+
+Tasks:
+
+- [ ] Add typed actions for rolling, spectator tiles, leg bets, and final bets.
+- [ ] Add `engine.actions` for legal action generation and stable legal action
+      masks.
+- [ ] Add tests for illegal choices and action-mask agreement.
+
+Acceptance criteria:
+
+- `get_legal_actions` and the legal action mask describe the same choices.
+- Equivalent states expose identical ordered actions and masks.
+- Action queries do not mutate state or advance turns.
+
+#### PR 6c: `feat: add deterministic turn progression`
+
+Suggested branch: `feat/turn-progression`
 
 Goal: Compose the completed rules from PR 5c behind one deterministic action
 and turn interface for all future consumers.
 
 Tasks:
 
-- [ ] Add typed actions for rolling, spectator tiles, leg bets, and final bets.
-- [ ] Add `engine.tiles` for tile placement and movement effects.
-- [ ] Add `engine.actions` for legal action generation and stable legal action
-      masks.
 - [ ] Add `engine.turn` for `apply_action`, current-player advancement, leg
       completion, game termination, and emitted events.
 - [ ] Keep action application atomic and expose no partially updated states.
-- [ ] Add tests for illegal actions, action-mask agreement, leg boundaries, and
+- [ ] Add tests for action application, leg boundaries, replay determinism, and
       terminal transitions.
 
 Acceptance criteria:
 
-- `get_legal_actions` and the legal action mask describe the same choices.
 - Replaying the same seed and action sequence produces the same states and
   events.
 - CLI, search, and RL code can share one action application API.
@@ -612,7 +666,7 @@ game state and rule APIs.
 
 Tasks:
 
-- [ ] Represent engine state with dataclasses such as `CamelPosition`,
+- [x] Represent engine state with dataclasses such as `CamelPosition`,
       `BoardState`, `GameState`, `DieRoll`, `SpectatorTile`, and player state.
 - [x] Inject or store `random.Random` instead of using global `random`.
 - [x] Remove printing and user input from engine logic.
@@ -646,8 +700,8 @@ High-priority areas:
 - [x] Moving a camel with camels above it.
 - [x] Crazy camel backward movement.
 - [x] Grey die behavior.
-- [ ] Spectator tile placement constraints.
-- [ ] Spectator tile movement effects.
+- [x] Spectator tile placement constraints.
+- [x] Spectator tile movement effects.
 - [ ] Leg reset behavior.
 - [x] End-of-game detection.
 - [x] Winner and runner-up ordering.

--- a/src/camel_up/engine/__init__.py
+++ b/src/camel_up/engine/__init__.py
@@ -36,6 +36,7 @@ from camel_up.engine.state import (
     spectator_tile_for_player,
     stack_at,
 )
+from camel_up.engine.tiles import place_spectator_tile, return_spectator_tiles
 
 __all__ = [
     "CAMEL_ORDER",
@@ -61,8 +62,10 @@ __all__ = [
     "move_camel",
     "position_of",
     "place_final_bet",
+    "place_spectator_tile",
     "rank_racing_camels",
     "reset_leg_dice",
+    "return_spectator_tiles",
     "roll_die",
     "setup_game",
     "settle_final_bets",

--- a/src/camel_up/engine/movement.py
+++ b/src/camel_up/engine/movement.py
@@ -17,6 +17,7 @@ from camel_up.engine.state import (
     position_of,
     stack_at,
 )
+from camel_up.engine.tiles import apply_spectator_tile_effect
 
 _CRAZY_CAMELS: Final = (CamelId.WHITE, CamelId.BLACK)
 
@@ -24,9 +25,11 @@ _CRAZY_CAMELS: Final = (CamelId.WHITE, CamelId.BLACK)
 def move_camel(state: GameState, roll: DieRoll) -> GameState:
     """Apply one physical die result to a fully set up game state.
 
-    The selected camel carries every camel above it and the complete unit lands
-    on top of any destination stack. Racing camels move forward; crazy camels
-    move backward. Crossing either finish boundary clamps the unit into that
+    The selected camel carries every camel above it. Racing camels move forward;
+    crazy camels move backward. A cheering spectator tile moves the unit one
+    additional space in its travel direction and places it on top of a stack;
+    a booing tile moves it one space against that direction and places it under
+    a stack. Crossing either finish boundary clamps the unit into that
     boundary's finish zone and makes the game terminal.
 
     Dice selection and removal are handled by :func:`roll_die`; this function
@@ -40,8 +43,7 @@ def move_camel(state: GameState, roll: DieRoll) -> GameState:
         A replacement state containing the moved camel unit.
 
     Raises:
-        ValueError: If setup is incomplete, the game is terminal, or the move
-            requires a spectator-tile effect that is not implemented yet.
+        ValueError: If setup is incomplete or the game is terminal.
     """
     _validate_movement_state(state)
     moving_camel = _resolve_moving_camel(state.board, roll)
@@ -53,23 +55,41 @@ def move_camel(state: GameState, roll: DieRoll) -> GameState:
         raw_destination = source.space - roll.distance
     else:
         raw_destination = source.space + roll.distance
-    destination, crossed_finish = _resolve_finish_zone(
+    landing_space, crossed_finish = _resolve_finish_zone(
         raw_destination,
         state.board.track_length,
     )
-    if not crossed_finish and any(
-        tile.space == destination for tile in state.board.spectator_tiles
-    ):
-        raise ValueError("spectator tile movement effects are not implemented")
-
     moving_unit = carried_camels(state.board, moving_camel)
-    destination_level = len(stack_at(state.board, destination))
+    place_under = False
+    if not crossed_finish:
+        state, tile_destination, place_under = apply_spectator_tile_effect(
+            state,
+            moving_camel,
+            landing_space,
+        )
+        destination, crossed_finish = _resolve_finish_zone(
+            tile_destination,
+            state.board.track_length,
+        )
+    else:
+        destination = landing_space
+
+    destination_stack = tuple(
+        camel
+        for camel in stack_at(state.board, destination)
+        if camel not in moving_unit
+    )
+    final_stack = (
+        (*moving_unit, *destination_stack)
+        if place_under
+        else (*destination_stack, *moving_unit)
+    )
     positions = list(state.board.camel_positions)
-    for level_offset, camel in enumerate(moving_unit):
+    for level, camel in enumerate(final_stack):
         camel_index = CAMEL_ORDER.index(camel)
         positions[camel_index] = CamelPosition(
             space=destination,
-            level=destination_level + level_offset,
+            level=level,
         )
 
     board = replace(state.board, camel_positions=tuple(positions))

--- a/src/camel_up/engine/state.py
+++ b/src/camel_up/engine/state.py
@@ -90,8 +90,9 @@ class CamelPosition:
 class SpectatorTile:
     """A placed spectator tile's owner, location, and movement effect.
 
-    This type records canonical tile state. Tile-placement actions, landing
-    effects, owner rewards, and leg resets belong to later rule transitions.
+    This type records canonical tile state. Tile placement and landing effects
+    are implemented by :mod:`camel_up.engine.tiles`; complete leg orchestration
+    belongs to the turn layer.
     """
 
     player_id: int

--- a/src/camel_up/engine/tiles.py
+++ b/src/camel_up/engine/tiles.py
@@ -1,0 +1,146 @@
+"""Deterministic spectator-tile placement and effect rules."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Literal
+
+from camel_up.engine.state import (
+    BoardState,
+    CamelId,
+    GameState,
+    PlayerState,
+    SpectatorTile,
+)
+
+_CRAZY_CAMELS = (CamelId.WHITE, CamelId.BLACK)
+
+
+def place_spectator_tile(
+    state: GameState,
+    player_id: int,
+    space: int,
+    effect: Literal[-1, 1],
+) -> GameState:
+    """Place or move one player's spectator tile.
+
+    Placement-specific board constraints are enforced by :class:`BoardState`:
+    the space must be empty, cannot be the first track space, and cannot be
+    adjacent to another spectator tile. A previously placed tile is removed
+    before the replacement position is validated.
+
+    This transition does not enforce whose turn it is. The future action layer
+    owns turn legality.
+
+    Args:
+        state: Active game state before placement.
+        player_id: Stable identity of the tile owner.
+        space: Zero-based track coordinate for the tile.
+        effect: ``1`` for cheering or ``-1`` for booing.
+
+    Returns:
+        A replacement state containing the canonically ordered tile.
+
+    Raises:
+        ValueError: If placement is unavailable or violates a tile rule.
+    """
+    _validate_tile_transition(state, player_id)
+    existing_tile = next(
+        (tile for tile in state.board.spectator_tiles if tile.player_id == player_id),
+        None,
+    )
+    if existing_tile is not None and existing_tile.space == space:
+        raise ValueError("a spectator tile must move to a different space")
+
+    tile = SpectatorTile(player_id=player_id, space=space, effect=effect)
+    other_tiles = tuple(
+        placed_tile
+        for placed_tile in state.board.spectator_tiles
+        if placed_tile.player_id != player_id
+    )
+    spectator_tiles = tuple(
+        sorted((*other_tiles, tile), key=lambda placed_tile: placed_tile.player_id)
+    )
+    board = replace(state.board, spectator_tiles=spectator_tiles)
+    return replace(state, board=board)
+
+
+def return_spectator_tiles(state: GameState) -> GameState:
+    """Return all placed spectator tiles at a leg boundary.
+
+    This tile-only transition is intended for later turn orchestration. It
+    leaves dice, scoring assets, player order, and the leg number unchanged.
+
+    Args:
+        state: A completed leg or terminal game.
+
+    Returns:
+        A replacement state with no spectator tiles on the board.
+
+    Raises:
+        ValueError: If setup is incomplete or the leg is still active.
+    """
+    if not all(position.is_placed for position in state.board.camel_positions):
+        raise ValueError("initial setup must be completed before returning tiles")
+    if not state.terminal and len(state.remaining_dice) != 1:
+        raise ValueError("spectator tiles can only return at a leg boundary")
+    if not state.board.spectator_tiles:
+        return state
+    return replace(state, board=replace(state.board, spectator_tiles=()))
+
+
+def apply_spectator_tile_effect(
+    state: GameState,
+    moving_camel: CamelId,
+    landing_space: int,
+) -> tuple[GameState, int, bool]:
+    """Apply the reward and displacement for a tile landing.
+
+    Args:
+        state: State immediately before the camel unit is placed.
+        moving_camel: Bottom camel of the moving unit.
+        landing_space: Space reached by the die movement.
+
+    Returns:
+        The rewarded state, displaced destination, and whether the moving unit
+        must be placed underneath the destination stack.
+    """
+    tile = _tile_at(state.board, landing_space)
+    if tile is None:
+        return state, landing_space, False
+
+    travel_direction = -1 if moving_camel in _CRAZY_CAMELS else 1
+    destination = landing_space + tile.effect * travel_direction
+    owner = state.players[tile.player_id]
+    rewarded_owner = replace(owner, money=owner.money + 1)
+    players = _replace_player(state.players, rewarded_owner)
+    return replace(state, players=players), destination, tile.effect == -1
+
+
+def _tile_at(board: BoardState, space: int) -> SpectatorTile | None:
+    """Return the spectator tile at ``space``, if one is present."""
+    return next((tile for tile in board.spectator_tiles if tile.space == space), None)
+
+
+def _validate_tile_transition(state: GameState, player_id: int) -> None:
+    """Reject states and player identities that cannot place a tile."""
+    if not 0 <= player_id < len(state.players):
+        raise ValueError(f"player_id {player_id} must identify a player in players")
+    if not all(position.is_placed for position in state.board.camel_positions):
+        raise ValueError("initial setup must be completed before placing a tile")
+    if state.terminal:
+        raise ValueError("cannot place a spectator tile after the game has ended")
+    if len(state.remaining_dice) <= 1:
+        raise ValueError("the leg is complete; settle it before placing a tile")
+
+
+def _replace_player(
+    players: tuple[PlayerState, ...],
+    updated_player: PlayerState,
+) -> tuple[PlayerState, ...]:
+    """Replace one canonically indexed player without mutating the tuple."""
+    return (
+        players[: updated_player.player_id]
+        + (updated_player,)
+        + players[updated_player.player_id + 1 :]
+    )

--- a/tests/engine/test_movement.py
+++ b/tests/engine/test_movement.py
@@ -346,24 +346,3 @@ def test_movement_rejects_incomplete_or_terminal_game() -> None:
     )
     with pytest.raises(ValueError, match="game has ended"):
         move_camel(replace(state, terminal=True), roll)
-
-
-def test_movement_defers_spectator_tile_effects_explicitly() -> None:
-    state = _state_with_stacks(
-        {
-            3: (CamelId.RED,),
-            4: (CamelId.BLUE,),
-            5: (CamelId.GREEN,),
-            6: (CamelId.YELLOW,),
-            7: (CamelId.PURPLE,),
-            10: (CamelId.WHITE,),
-            12: (CamelId.BLACK,),
-        },
-        spectator_tiles=(SpectatorTile(player_id=0, space=8, effect=1),),
-    )
-
-    with pytest.raises(ValueError, match="tile movement effects"):
-        move_camel(
-            state,
-            DieRoll(die=DieId.PURPLE, camel=CamelId.PURPLE, distance=1),
-        )

--- a/tests/engine/test_tiles.py
+++ b/tests/engine/test_tiles.py
@@ -1,0 +1,292 @@
+from dataclasses import replace
+from typing import Literal
+
+import pytest
+
+from camel_up.engine import (
+    CAMEL_ORDER,
+    DIE_ORDER,
+    MIN_PLAYERS,
+    BoardState,
+    CamelId,
+    CamelPosition,
+    DieId,
+    DieRoll,
+    GameState,
+    PlayerState,
+    SpectatorTile,
+    move_camel,
+    place_spectator_tile,
+    return_spectator_tiles,
+    stack_at,
+)
+
+
+def _state_with_stacks(
+    stacks: dict[int, tuple[CamelId, ...]],
+    *,
+    spectator_tiles: tuple[SpectatorTile, ...] = (),
+    remaining_dice: tuple[DieId, ...] = DIE_ORDER,
+) -> GameState:
+    """Build a complete state from bottom-to-top stack definitions."""
+    positions_by_camel = {
+        camel: CamelPosition(space=space, level=level)
+        for space, stack in stacks.items()
+        for level, camel in enumerate(stack)
+    }
+    if set(positions_by_camel) != set(CAMEL_ORDER):
+        raise ValueError("test stacks must place every camel exactly once")
+    return GameState(
+        board=BoardState(
+            track_length=16,
+            camel_positions=tuple(positions_by_camel[camel] for camel in CAMEL_ORDER),
+            spectator_tiles=spectator_tiles,
+        ),
+        players=tuple(PlayerState(player_id=index) for index in range(MIN_PLAYERS)),
+        remaining_dice=remaining_dice,
+    )
+
+
+def _spread_state(
+    *,
+    spectator_tiles: tuple[SpectatorTile, ...] = (),
+    remaining_dice: tuple[DieId, ...] = DIE_ORDER,
+) -> GameState:
+    return _state_with_stacks(
+        {
+            2: (CamelId.RED,),
+            7: (CamelId.BLUE,),
+            6: (CamelId.GREEN,),
+            8: (CamelId.YELLOW,),
+            10: (CamelId.PURPLE,),
+            12: (CamelId.WHITE,),
+            14: (CamelId.BLACK,),
+        },
+        spectator_tiles=spectator_tiles,
+        remaining_dice=remaining_dice,
+    )
+
+
+def test_place_and_move_spectator_tile_immutably_in_canonical_order() -> None:
+    state = place_spectator_tile(_spread_state(), 2, 9, -1)
+    state = place_spectator_tile(state, 0, 3, 1)
+    moved = place_spectator_tile(state, 2, 11, 1)
+
+    assert moved.board.spectator_tiles == (
+        SpectatorTile(player_id=0, space=3, effect=1),
+        SpectatorTile(player_id=2, space=11, effect=1),
+    )
+    assert state.board.spectator_tiles[-1] == SpectatorTile(
+        player_id=2,
+        space=9,
+        effect=-1,
+    )
+
+
+@pytest.mark.parametrize(
+    ("space", "message"),
+    [
+        (0, "track space 1"),
+        (2, "space with camels"),
+        (4, "adjacent spaces"),
+    ],
+)
+def test_tile_placement_enforces_board_constraints(
+    space: int,
+    message: str,
+) -> None:
+    state = _spread_state(
+        spectator_tiles=(SpectatorTile(player_id=1, space=5, effect=1),)
+    )
+
+    with pytest.raises(ValueError, match=message):
+        place_spectator_tile(state, 0, space, -1)
+
+
+def test_tile_must_move_to_a_different_space() -> None:
+    state = _spread_state(
+        spectator_tiles=(SpectatorTile(player_id=0, space=3, effect=1),)
+    )
+
+    with pytest.raises(ValueError, match="different space"):
+        place_spectator_tile(state, 0, 3, -1)
+
+
+@pytest.mark.parametrize("player_id", [-1, MIN_PLAYERS])
+def test_tile_placement_rejects_unknown_player(player_id: int) -> None:
+    with pytest.raises(ValueError, match="must identify a player"):
+        place_spectator_tile(_spread_state(), player_id, 3, 1)
+
+
+def test_tile_placement_requires_an_active_setup_game() -> None:
+    with pytest.raises(ValueError, match="setup must be completed"):
+        place_spectator_tile(GameState.pre_setup(), 0, 3, 1)
+
+    state = _spread_state()
+    with pytest.raises(ValueError, match="game has ended"):
+        place_spectator_tile(replace(state, terminal=True), 0, 3, 1)
+
+    with pytest.raises(ValueError, match="leg is complete"):
+        place_spectator_tile(
+            replace(state, remaining_dice=(DieId.GREY,)),
+            0,
+            3,
+            1,
+        )
+
+
+def test_cheering_tile_moves_racing_unit_forward_onto_destination_stack() -> None:
+    state = _state_with_stacks(
+        {
+            3: (CamelId.RED, CamelId.BLUE),
+            6: (CamelId.GREEN,),
+            8: (CamelId.YELLOW,),
+            10: (CamelId.PURPLE,),
+            12: (CamelId.WHITE,),
+            14: (CamelId.BLACK,),
+        },
+        spectator_tiles=(SpectatorTile(player_id=1, space=5, effect=1),),
+    )
+
+    moved = move_camel(
+        state,
+        DieRoll(die=DieId.RED, camel=CamelId.RED, distance=2),
+    )
+
+    assert stack_at(moved.board, 5) == ()
+    assert stack_at(moved.board, 6) == (
+        CamelId.GREEN,
+        CamelId.RED,
+        CamelId.BLUE,
+    )
+    assert moved.players[1].money == 4
+    assert moved.board.spectator_tiles == state.board.spectator_tiles
+    assert state.players[1].money == 3
+
+
+def test_booing_tile_places_racing_unit_under_destination_stack() -> None:
+    state = _state_with_stacks(
+        {
+            3: (CamelId.GREEN, CamelId.RED, CamelId.BLUE),
+            4: (CamelId.YELLOW, CamelId.PURPLE),
+            10: (CamelId.WHITE,),
+            14: (CamelId.BLACK,),
+        },
+        spectator_tiles=(SpectatorTile(player_id=0, space=5, effect=-1),),
+    )
+
+    moved = move_camel(
+        state,
+        DieRoll(die=DieId.RED, camel=CamelId.RED, distance=2),
+    )
+
+    assert stack_at(moved.board, 3) == (CamelId.GREEN,)
+    assert stack_at(moved.board, 4) == (
+        CamelId.RED,
+        CamelId.BLUE,
+        CamelId.YELLOW,
+        CamelId.PURPLE,
+    )
+    assert moved.players[0].money == 4
+
+
+@pytest.mark.parametrize(
+    ("effect", "destination"),
+    [(1, 7), (-1, 9)],
+)
+def test_crazy_camel_reverses_tile_displacement(
+    effect: Literal[-1, 1],
+    destination: int,
+) -> None:
+    state = _state_with_stacks(
+        {
+            2: (CamelId.RED,),
+            4: (CamelId.BLUE,),
+            6: (CamelId.GREEN,),
+            10: (CamelId.WHITE, CamelId.YELLOW),
+            12: (CamelId.PURPLE,),
+            14: (CamelId.BLACK,),
+        },
+        spectator_tiles=(SpectatorTile(player_id=2, space=8, effect=effect),),
+    )
+
+    moved = move_camel(
+        state,
+        DieRoll(die=DieId.GREY, camel=CamelId.WHITE, distance=2),
+    )
+
+    assert stack_at(moved.board, destination) == (CamelId.WHITE, CamelId.YELLOW)
+    assert moved.players[2].money == 4
+
+
+def test_booing_tile_can_return_unit_beneath_its_source_stack() -> None:
+    state = _state_with_stacks(
+        {
+            3: (CamelId.GREEN, CamelId.RED, CamelId.BLUE),
+            6: (CamelId.YELLOW,),
+            10: (CamelId.PURPLE,),
+            12: (CamelId.WHITE,),
+            14: (CamelId.BLACK,),
+        },
+        spectator_tiles=(SpectatorTile(player_id=0, space=4, effect=-1),),
+    )
+
+    moved = move_camel(
+        state,
+        DieRoll(die=DieId.RED, camel=CamelId.RED, distance=1),
+    )
+
+    assert stack_at(moved.board, 3) == (
+        CamelId.RED,
+        CamelId.BLUE,
+        CamelId.GREEN,
+    )
+
+
+def test_tile_displacement_can_end_the_game() -> None:
+    state = _state_with_stacks(
+        {
+            2: (CamelId.BLUE,),
+            4: (CamelId.GREEN,),
+            6: (CamelId.YELLOW,),
+            8: (CamelId.PURPLE,),
+            10: (CamelId.WHITE,),
+            12: (CamelId.BLACK,),
+            14: (CamelId.RED,),
+        },
+        spectator_tiles=(SpectatorTile(player_id=0, space=15, effect=1),),
+    )
+
+    moved = move_camel(
+        state,
+        DieRoll(die=DieId.RED, camel=CamelId.RED, distance=1),
+    )
+
+    assert moved.terminal
+    assert stack_at(moved.board, 16) == (CamelId.RED,)
+    assert moved.players[0].money == 4
+
+
+def test_return_spectator_tiles_only_changes_board_at_leg_boundary() -> None:
+    tile = SpectatorTile(player_id=0, space=3, effect=1)
+    state = _spread_state(
+        spectator_tiles=(tile,),
+        remaining_dice=(DieId.GREY,),
+    )
+
+    returned = return_spectator_tiles(state)
+
+    assert returned.board.spectator_tiles == ()
+    assert returned.players == state.players
+    assert returned.remaining_dice == state.remaining_dice
+    assert returned.leg_number == state.leg_number
+    assert state.board.spectator_tiles == (tile,)
+    assert return_spectator_tiles(returned) is returned
+
+
+def test_return_spectator_tiles_rejects_incomplete_or_active_leg() -> None:
+    with pytest.raises(ValueError, match="setup must be completed"):
+        return_spectator_tiles(GameState.pre_setup())
+
+    with pytest.raises(ValueError, match="leg boundary"):
+        return_spectator_tiles(_spread_state())


### PR DESCRIPTION
## Outcome

Complete deterministic spectator-tile rules before legal-action indexing and turn orchestration are introduced.

## Changes

- add immutable spectator-tile placement and replacement
- apply cheering and booing displacement during camel movement
- reverse tile displacement for crazy camels
- preserve carried-stack order and place booing units beneath destination stacks
- award the tile owner 1 EP and retain the tile until leg cleanup
- add a focused leg-boundary transition for returning tiles
- expose the stable tile APIs through camel_up.engine
- split the remaining roadmap into PRs 6a, 6b, and 6c

## Non-goals

- typed player actions or stable action indices
- legal-action generation or masks
- turn advancement, emitted events, or complete leg orchestration
- CLI migration, agents, or RL environments

## Verification

- uv run python -m pytest: 130 passed
- uv run ruff check .: passed
- uv run ruff format --check .: passed
- uv run python -m mypy: passed
- git diff --check: passed